### PR TITLE
Use consistent shared note terminology

### DIFF
--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -1329,7 +1329,7 @@ The origin of a name might be a reasonable shared note, while the reason a parti
 :::
 
 :::note
-Although sharable notes have been present since version 5.0 was released in 1991, as of 2021 relatively few applications have a user interface that presents shared notes as such to users. It is recommended that `SNOTE` be avoided when `NOTE` will suffice.
+Although shared notes have been present since version 5.0 was released in 1991, as of 2021 relatively few applications have a user interface that presents shared notes as such to users. It is recommended that `SNOTE` be avoided when `NOTE` will suffice.
 :::
 
 A `SHARED_NOTE_RECORD` may contain a pointer to a `SOURCE_RECORD` and vice versa. Applications must not create datasets where these mutual pointers form a cycle. Applications should also ensure they can handle invalid files with such cycles in a safe manner.

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -1329,7 +1329,8 @@ The origin of a name might be a reasonable shared note, while the reason a parti
 :::
 
 :::note
-Although shared notes have been present since version 5.0 was released in 1991, as of 2021 relatively few applications have a user interface that presents shared notes as such to users. It is recommended that `SNOTE` be avoided when `NOTE` will suffice.
+The ability to have multiple structures share a single note using pointers was introduced in version 5.0 in 1991.
+However, as of 2021 relatively few applications have a user interface that presents shared notes as such to users. It is recommended that `SNOTE` be avoided when `NOTE` will suffice.
 :::
 
 A `SHARED_NOTE_RECORD` may contain a pointer to a `SOURCE_RECORD` and vice versa. Applications must not create datasets where these mutual pointers form a cycle. Applications should also ensure they can handle invalid files with such cycles in a safe manner.


### PR DESCRIPTION
use "shared note" (like everywhere else in the doc), not "sharable note"

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>