### PR TITLE
Fix head lang

### DIFF
--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2830,9 +2830,20 @@ A [registry of component subtags](https://www.iana.org/assignments/language-subt
 
 #### `LANG` (Language) `g7:HEAD-LANG`
 
-The language in which the `Text`-typed payloads of all structures in the document appear, except as superseded by a `g7:LANG`.
+The language in which the `Text`-typed payloads of all structures in the dataset appear, except as superseded by a `g7:LANG`.
+This structure must not be used unless the languages of all such payloads can be described by the same language tag.
 
 The payload of the `LANG` structure is a language tag, as defined by [BCP 47](https://www.rfc-editor.org/info/bcp47).
+
+If this structure is not included in a dataset, it has the same meaning as if it is present with the payload `und`, meaning the default language is undetermined.
+Per section 4.1 of [RFC 5646](https://www.rfc-editor.org/info/rfc5646), `g7:HEAD-LANG` should be omitted if its payload would be `und`.
+
+:::note
+There is a language tag `mul` meaning "multiple languages".
+However, it is not appropriate as a `g7:HEAD-LANG` payload unless every `Text`-typed payload without its own `g7:LANG` substructure is a string with parts in several languages.
+If some payloads are in one language and other payloads in a different language,
+the language of any given payload is undetermined (`und`), not multiple.
+:::
 
 #### `LANG` (Language) `g7:SUBM-LANG`
 

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -21,7 +21,7 @@ All version of GEDCOM files are text files that conform to the following general
     - The first line's level is 0.
     - Each other line's level is at most on greater than the the level of the line before it.
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
-  3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`-`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
+  3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`–`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.
 - Each line represents a structure. Any line with level *x* > 0 represents a substructure of the structure represented by the nearest preceding line with level *x* − 1.
 

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -11,6 +11,25 @@ to parse the data.  The GEDCOM format itself does include a version identifier i
 a parser can detect the correct version and parse the file accordingly.  This document specifies a version
 detection algorithm and provides references to the more specific format specifications.
 
+## Commonalities
+
+All GEDCOM versions are text files that conform to the following general structure:
+
+- The document is organized as a sequence of **lines** separated by ASCII line terminators (U+000A, U+000D, or both)
+- Each line contains several components, separated by spaces (U+0020):
+  1. A required **level**, which is a non-negative integer encoded using ASCII digits.
+    The first level is always 0.
+    Each line's level is between 0 and 1 + the preceding line's level, inclusive.
+  2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
+  3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`-`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
+  4. An optional **value**, which may contain any non-line terminator character.
+- Each line represents a structure.
+- Any line with level *x* > 0 represents a substructure of the nearest preceding line with level *x* − 1.
+
+Beyond these commonalities, each GEDCOM version differs in details and is described by its own specification.
+Version specifications typically describe both the meaning of various structures
+and provide additional serialization details, including whether blank lines are allowed, whether multiple spaces can be used to separate line components, limits on tag and identifier length and characters, etc.
+
 ## Character Width and Byte Order Detection
 
 To efficiently locate the version in the content, one can first determine the character width and byte order

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -13,7 +13,7 @@ detection algorithm and provides references to the more specific format specific
 
 ## Commonalities
 
-All GEDCOM versions are text files that conform to the following general structure:
+All version of GEDCOM files are text files that conform to the following general structure:
 
 - The document is organized as a sequence of **lines** separated by ASCII line terminators (U+000A, U+000D, or both)
 - Each line contains several components, separated by spaces (U+0020):
@@ -23,8 +23,7 @@ All GEDCOM versions are text files that conform to the following general structu
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
   3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`-`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.
-- Each line represents a structure.
-- Any line with level *x* > 0 represents a substructure of the nearest preceding line with level *x* − 1.
+- Each line represents a structure. Any line with level *x* > 0 represents a substructure of the nearest preceding line with level *x* − 1.
 
 Beyond these commonalities, each GEDCOM version differs in details and is described by its own specification.
 Version specifications typically describe both the meaning of various structures

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -19,7 +19,7 @@ All version of GEDCOM files are text files that conform to the following general
 - Each line contains several components, separated by spaces (U+0020):
   1. A required **level**, which is a non-negative integer encoded using ASCII digits.
     - The first line's level is 0.
-    - Each other line's level is at most on greater than the the level of the line before it.
+    - Each other line's level is at most on greater than the level of the line before it.
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
   3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`–`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -19,7 +19,7 @@ All version of GEDCOM files are text files that conform to the following general
 - Each line contains several components, separated by spaces (U+0020):
   1. A required **level**, which is a non-negative integer encoded using ASCII digits.
     - The first line's level is 0.
-    - Each other line's level is at most on greater than the level of the line before it.
+    - Each other line's level is at most 1 greater than the level of the line before it.
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
   3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`–`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -15,11 +15,11 @@ detection algorithm and provides references to the more specific format specific
 
 All version of GEDCOM files are text files that conform to the following general structure:
 
-- The document is organized as a sequence of **lines** separated by ASCII line terminators (U+000A, U+000D, or both)
+- The document is organized as a sequence of **lines** separated by ASCII line terminators (U+000A, U+000D, or both). Blank lines are ignored.
 - Each line contains several components, separated by spaces (U+0020):
   1. A required **level**, which is a non-negative integer encoded using ASCII digits.
-    The first level is always 0.
-    Each line's level is between 0 and 1 + the preceding line's level, inclusive.
+    - The first line's level is 0.
+    - Each other line's level is at most on greater than the the level of the line before it.
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
   3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`-`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.

--- a/version-detection/version-detection.md
+++ b/version-detection/version-detection.md
@@ -23,7 +23,7 @@ All version of GEDCOM files are text files that conform to the following general
   2. An optional **identifier**, which begins and ends with a COMMERCIAL AT (U+0040 `@`) and contains no internal line terminators or COMMERCIAL ATs. No two lines share the same identifier.
   3. A required **tag**, which is a string of one or more ASCII digits (U+0030 through U+0039 `9`-`0`), letters (U+0041 through U+005A `A`–`Z` and U+0061 through U+007A `a`–`z`), and underscores (U+005F `_`).
   4. An optional **value**, which may contain any non-line terminator character.
-- Each line represents a structure. Any line with level *x* > 0 represents a substructure of the nearest preceding line with level *x* − 1.
+- Each line represents a structure. Any line with level *x* > 0 represents a substructure of the structure represented by the nearest preceding line with level *x* − 1.
 
 Beyond these commonalities, each GEDCOM version differs in details and is described by its own specification.
 Version specifications typically describe both the meaning of various structures


### PR DESCRIPTION
Clarifies that `g7:HEAD-LANG` should only be used if *all* Text-type payloads with no `g7:LANG` substructure are in the same language.