### PR TITLE
Change email address

### DIFF
--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -1,7 +1,7 @@
 ---
 title: The FamilySearch GEDCOM Specification
 subtitle: 7.0.5
-email: GEDCOM@ChurchOfJesusChrist.org
+email: GEDCOM@FamilySearch.org
 copyright: |
     :::{style="page-break-after: always;page-break-before: always;"}
     Copyright 1984–2021 Intellectual Reserve, Inc. All rights reserved. A service provided by The Church of Jesus Christ of Latter-day Saints.


### PR DESCRIPTION
Change from GEDCOM@ChurchOfJesusChrist.org to GEDCOM@FamilySearch.org to reduce the total number of contact email addresses in use as discussed in steering committee 2021-10-05