### PR TITLE
Deprecation EXID without TYPE

### DIFF
--- a/build/pandoc.css
+++ b/build/pandoc.css
@@ -429,6 +429,17 @@ div.sourceCode {
     font-style: italic;
 }
 
+.deprecation {
+    margin: 1em;
+    background: #fbe9e9;
+    border-left: #f99 solid 4px;
+    padding: 0em 0.5em;
+}
+.deprecation > :first-child:before {
+    content: "Deprecation Note \2014\00A0 ";
+    font-style: italic;
+}
+
 code.uri {
     font-weight: normal;
     background: none !important;

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2675,12 +2675,6 @@ the authority owning the identifier is provided in the TYPE substructure; see `E
 
 Depending on the maintaining authority, an `EXID` may be a unique identifier for the subject, an identifier for 1 of several views of the subject, or an identifier for the externally-maintained copy of the same information as is contained in this structure. However, unlike `UID` and `REFN`, `EXID` does not identify a structure; structures with the same `EXID` may have originated independently rather than by edits from the same starting point.
 
-:::deprecation
-Having an `EXID` without an `EXID`.`TYPE` substructure is deprecated.
-The meaning of an `EXID` depends on its `EXID`.`TYPE`.
-The cardinality of `EXID`.`TYPE` will be changed to `{1:1}` in version 8.0.
-:::
-
 #### `FAM` (Family record) `g7:record-FAM`
 
 See `FAMILY_RECORD`

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -1641,6 +1641,12 @@ n EXID <Special>                           {1:1}  g7:EXID
 ]
 ```
 
+:::deprecation
+Having an `EXID` without an `EXID`.`TYPE` substructure is deprecated.
+The meaning of an `EXID` depends on its `EXID`.`TYPE`.
+The cardinality of `EXID`.`TYPE` will be changed to `{1:1}` in version 8.0.
+:::
+
 Each of these provides an identifier for a structure or its subject,
 and each is different in purpose:
 
@@ -1649,6 +1655,7 @@ and each is different in purpose:
 - `UID` is a globally-unique identifier for a structure.
 
 - `EXID` is an identifier maintained by an external authority that applies to the subject of the structure.
+
 
 #### `INDIVIDUAL_ATTRIBUTE_STRUCTURE` :=
 
@@ -2048,6 +2055,13 @@ n PLAC <List:Text>                         {1:1}  g7:PLAC
   +1 <<NOTE_STRUCTURE>>                    {0:M}
 ```
 
+:::deprecation
+Having an `EXID` without an `EXID`.`TYPE` substructure is deprecated.
+The meaning of an `EXID` depends on its `EXID`.`TYPE`.
+The cardinality of `EXID`.`TYPE` will be changed to `{1:1}` in version 8.0.
+:::
+
+
 A place, which can be represented in several ways:
 
 - The payload contains a comma-separated list of region names,
@@ -2076,6 +2090,8 @@ A place, which can be represented in several ways:
 :::note
 This specification does not support places where a region name contains a comma. An alternative system for representing locations is likely to be added in a later version.
 :::
+
+
 
 #### `SOURCE_CITATION` :=
 
@@ -2658,6 +2674,12 @@ The identifier is maintained by some external authority;
 the authority owning the identifier is provided in the TYPE substructure; see `EXID`.`TYPE` for more.
 
 Depending on the maintaining authority, an `EXID` may be a unique identifier for the subject, an identifier for 1 of several views of the subject, or an identifier for the externally-maintained copy of the same information as is contained in this structure. However, unlike `UID` and `REFN`, `EXID` does not identify a structure; structures with the same `EXID` may have originated independently rather than by edits from the same starting point.
+
+:::deprecation
+Having an `EXID` without an `EXID`.`TYPE` substructure is deprecated.
+The meaning of an `EXID` depends on its `EXID`.`TYPE`.
+The cardinality of `EXID`.`TYPE` will be changed to `{1:1}` in version 8.0.
+:::
 
 #### `FAM` (Family record) `g7:record-FAM`
 


### PR DESCRIPTION
As per #80, EXID without TYPE is meaningless and should not be used.

I put it three places: in both `IDENTIFIER_STRUCTURE` and `PLACE_STRUCTURE` (which list the EXID/TYPE relationship) and the description of EXID (so that it will show up in the tag definition served at <https://gedcom.io/terms/v7/EXID>)

I've also added a new "deprecation note" environment to the CSS to make this stand out more in the rendered HTML and PDF.