### PR TITLE
remove reference to CONT in ADR1-3 per #94

### DIFF
--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2313,7 +2313,7 @@ An [enumerated value](#enum-ADOP) indicating which parent(s) in the family adopt
 #### `ADR1` (Address Line 1) `g7:ADR1`
 
 The first line of the address, used for indexing.
-This should have a payload with no line break and be equal to the the first line of the corresponding `ADDR`.
+This structure's payload should be a single line of text equal to the first line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `ADR2` (Address Line 2) `g7:ADR2`

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2319,7 +2319,7 @@ See `ADDRESS_STRUCTURE` for more.
 #### `ADR2` (Address Line 2) `g7:ADR2`
 
 The second line of the address, used for indexing.
-This should have a payload with no line break and be equal to the the second line of the corresponding `ADDR`.
+This structure's payload should be a single line of text equal to the second line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `ADR3` (Address Line 3) `g7:ADR3`

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2313,19 +2313,19 @@ An [enumerated value](#enum-ADOP) indicating which parent(s) in the family adopt
 #### `ADR1` (Address Line 1) `g7:ADR1`
 
 The first line of the address, used for indexing.
-This is the value of the line corresponding to the `ADDR` tag line in the address structure.
+This should have a payload with no line break and be equal to the the first line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `ADR2` (Address Line 2) `g7:ADR2`
 
 The second line of the address, used for indexing.
-This is the value of the first `CONT` line subordinate to the `ADDR` tag in the address structure.
+This should have a payload with no line break and be equal to the the second line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `ADR3` (Address Line 3) `g7:ADR3`
 
 The third line of the address, used for indexing.
-This is the value of the second `CONT` line subordinate to the `ADDR` tag in the address structure.
+This should have a payload with no line break and be equal to the the third line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `AGE` (Age at event) `g7:AGE`

--- a/specification/gedcom.md
+++ b/specification/gedcom.md
@@ -2325,7 +2325,7 @@ See `ADDRESS_STRUCTURE` for more.
 #### `ADR3` (Address Line 3) `g7:ADR3`
 
 The third line of the address, used for indexing.
-This should have a payload with no line break and be equal to the the third line of the corresponding `ADDR`.
+This structure's payload should be a single line of text equal to the third line of the corresponding `ADDR`.
 See `ADDRESS_STRUCTURE` for more.
 
 #### `AGE` (Age at event) `g7:AGE`


### PR DESCRIPTION
Old ADR1 through ADR3 were copied from 5.5.1 and referenced CONT, which does not make sense in 7.0's presentation