### PR TITLE
Serve URLs for g7:AFN g7:RFN and g7:RIN

### DIFF
--- a/build/uri-def.py
+++ b/build/uri-def.py
@@ -1,8 +1,10 @@
 import re
 from sys import argv, stderr
-from os.path import isfile, isdir, exists, dirname, join
+from os.path import isfile, isdir, exists, dirname, join, basename
 from os import makedirs
 from subprocess import run
+from shutil import copyfile
+from glob import glob
 
 
 def get_paths():
@@ -285,6 +287,11 @@ if __name__ == '__main__':
 
     for tag in g7:
         print('outputting', tag, '...', end=' ')
+        maybe = join(dirname(spec),'terms',tag)
+        if exists(maybe):
+            copyfile(maybe, join(dest,tag))
+            print('by copying', maybe, '...', end=' ')
+            continue
         with open(join(dest,tag), 'w') as fh:
             fh.write('%YAML 1.2\n---\n')
             print('type:',g7[tag][0], file=fh)
@@ -330,6 +337,13 @@ if __name__ == '__main__':
             fh.write('...\n')
 
         print('done')
+    
+    for path in glob(join(dirname(spec),'terms','*')):
+        tag = basename(path)
+        if tag not in g7:
+            print('copying', tag, '...', end=' ')
+            copyfile(path, join(dest,tag))
+            print('done')
 
     if dest.endswith('/'): dest=dest[:-1]
     base = dirname(dest)

--- a/extracted-files/tags/AFN
+++ b/extracted-files/tags/AFN
@@ -6,8 +6,10 @@ uri: https://gedcom.io/terms/v7/AFN
 
 descriptions:
   - Ancestral File Number
-  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
-    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the
+    https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's AFN structure.
     
     Ancestral File is a computerized collection of genealogies that links 
@@ -15,6 +17,6 @@ descriptions:
     File Number was assigned to every record that was published in Ancestral
     File.
     
-    See <https://www.familysearch.org/wiki/en/Ancestral_File> for more.
+    See https://www.familysearch.org/wiki/en/Ancestral_File for more.
 
 ...

--- a/extracted-files/tags/AFN
+++ b/extracted-files/tags/AFN
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/AFN
+
+descriptions:
+  - Ancestral File Number
+  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's AFN structure.
+    
+    Ancestral File is a computerized collection of genealogies that links 
+    families into pedigrees, showing ancestors and descendants. An Ancestral
+    File Number was assigned to every record that was published in Ancestral
+    File.
+    
+    See <https://www.familysearch.org/wiki/en/Ancestral_File> for more.
+
+...

--- a/extracted-files/tags/AFN
+++ b/extracted-files/tags/AFN
@@ -6,7 +6,7 @@ uri: https://gedcom.io/terms/v7/AFN
 
 descriptions:
   - Ancestral File Number
-  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
     It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's AFN structure.
     

--- a/extracted-files/tags/RFN
+++ b/extracted-files/tags/RFN
@@ -6,16 +6,18 @@ uri: https://gedcom.io/terms/v7/RFN
 
 descriptions:
   - Record File Number
-  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
-    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the 
+    https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's RFN structure.
 
-    GEDCOM versions 5 through 5.5.1 had a notion of a "registered resource identifier".
-    The registration process was never widely followed and ceased being used in
-    the early 2000s. URLs beginning https://gedcom.io/terms/v7/RFN are
-    placeholders for such "registered resource identifiers", which may or may
-    not have been registered and hence may or may not be a unique resource
-    identifier.
+    GEDCOM versions 5.0 through 5.5.1 had a notion of a "registered resource
+    identifier". The registration process was never widely followed and ceased
+    being used in the early 2000s. URLs beginning
+    https://gedcom.io/terms/v7/RFN are placeholders for such "registered
+    resource identifiers", which may or may not have been registered and hence
+    may or may not be a unique resource identifier.
     
     The fragment identifer of this URI (the part after the #) is the
     registered resource identifier; the payload of the EXID is the record
@@ -26,11 +28,11 @@ descriptions:
     
     It is recommend that the 5.5.1 structure
     
-    2 RFN xyz:123abc
+        2 RFN xyz:123abc
     
     be converted to 7.0 structures
     
-    2 EXID xyz
-    3 TYPE https://gedcom.io/terms/v7/RFN#123abc
+        2 EXID xyz
+        3 TYPE https://gedcom.io/terms/v7/RFN#123abc
 
 ...

--- a/extracted-files/tags/RFN
+++ b/extracted-files/tags/RFN
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/RFN
+
+descriptions:
+  - Record File Number
+  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's RFN structure.
+
+    GEDCOM 5 through 5.5.1 had a notion of a "registered resource identifier".
+    The registration process was never widely followed and ceased being used in
+    the early 2000s. URLs beginning https://gedcom.io/terms/v7/RFN are
+    placeholders for such "registered resource identifiers", which may or may
+    not have been registered and hence may or may not be a unique resource
+    identifier.
+    
+    The fragment identifer of this URI (the part after the #) is the
+    registered resource identifier; the payload of the EXID is the record
+    identifier within that resource. If there is no fragment identifier,
+    the EXID may represent either a registered number of a submitter of
+    Ancestral File data (see https://gedcom.io/terms/v7/AFN) or may have been
+    created by a user omitting to indicate the resource in 5.5.1 or earlier.
+    
+    It is recommend that the 5.5.1 structure
+    
+    2 RFN xyz:123abc
+    
+    be converted to 7.0 structures
+    
+    2 EXID xyz
+    3 TYPE https://gedcom.io/terms/v7/RFN#123abc
+
+...

--- a/extracted-files/tags/RFN
+++ b/extracted-files/tags/RFN
@@ -10,7 +10,7 @@ descriptions:
     It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's RFN structure.
 
-    GEDCOM 5 through 5.5.1 had a notion of a "registered resource identifier".
+    GEDCOM versions 5 through 5.5.1 had a notion of a "registered resource identifier".
     The registration process was never widely followed and ceased being used in
     the early 2000s. URLs beginning https://gedcom.io/terms/v7/RFN are
     placeholders for such "registered resource identifiers", which may or may

--- a/extracted-files/tags/RFN
+++ b/extracted-files/tags/RFN
@@ -6,7 +6,7 @@ uri: https://gedcom.io/terms/v7/RFN
 
 descriptions:
   - Record File Number
-  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
     It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's RFN structure.
 

--- a/extracted-files/tags/RIN
+++ b/extracted-files/tags/RIN
@@ -6,8 +6,10 @@ uri: https://gedcom.io/terms/v7/RIN
 
 descriptions:
   - Record ID Number
-  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
-    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the
+    https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's RIN structure.
 
     GEDCOM 5.5 and 5.5.1 defined RIN as follows:
@@ -26,12 +28,12 @@ descriptions:
     
     It is recommend that the 5.5.1 structure
     
-    2 RIN 123abc
+        2 RIN 123abc
     
     in a file with HEAD.SOUR line value "XYZ"
     be converted to 7.0 structures
     
-    2 EXID 123abc
-    3 TYPE https://gedcom.io/terms/v7/RIN#XYZ
+        2 EXID 123abc
+        3 TYPE https://gedcom.io/terms/v7/RIN#XYZ
 
 ...

--- a/extracted-files/tags/RIN
+++ b/extracted-files/tags/RIN
@@ -6,7 +6,7 @@ uri: https://gedcom.io/terms/v7/RIN
 
 descriptions:
   - Record ID Number
-  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+  - This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch GEDCOM 7.0 and beyond.
     It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's RIN structure.
 

--- a/extracted-files/tags/RIN
+++ b/extracted-files/tags/RIN
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/RIN
+
+descriptions:
+  - Record ID Number
+  - This URI is defined to support conversion from 5.5.1 to 7.0 and beyond.
+    It is intended for use as the https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's RIN structure.
+
+    GEDCOM 5.5 and 5.5.1 defined RIN as follows:
+    
+    > A unique record identification number assigned to the record by the
+    > source system. This number is intended to serve as a more sure means of
+    > identification of a record for reconciling differences in data between
+    > two interfacing systems.
+    
+    URLs beginning https://gedcom.io/terms/v7/RIN are used to represent
+    such source systems if they did not have a dedicated URI. The fragment
+    identifer of this URI (the part after the #) represents how the source
+    system was identified in the 5.5 or 5.5.1 file's header; the payload of the
+    EXID is the record identifier within that resource. If there is no fragment
+    identifier, the EXID was an RIN given without a source system identifier.
+    
+    It is recommend that the 5.5.1 structure
+    
+    2 RIN 123abc
+    
+    in a file with HEAD.SOUR line value "XYZ"
+    be converted to 7.0 structures
+    
+    2 EXID 123abc
+    3 TYPE https://gedcom.io/terms/v7/RIN#XYZ
+
+...

--- a/specification/terms/AFN
+++ b/specification/terms/AFN
@@ -13,9 +13,10 @@ descriptions:
     https://gedcom.io/terms/v7/EXID replacing 5.5.1's AFN structure.
     
     Ancestral File is a computerized collection of genealogies that links 
-    families into pedigrees, showing ancestors and descendants. An Ancestral
-    File Number was assigned to every record that was published in Ancestral
-    File.
+    families into pedigrees, showing ancestors and descendants. Ancestral 
+    File was created from thousands of user submitted pedigree charts, family 
+    group sheets, and GEDCOM files. An Ancestral File Number was assigned to
+    every record that was published in Ancestral File.
     
     See https://www.familysearch.org/wiki/en/Ancestral_File for more.
 

--- a/specification/terms/AFN
+++ b/specification/terms/AFN
@@ -1,0 +1,22 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/AFN
+
+descriptions:
+  - Ancestral File Number
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the
+    https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's AFN structure.
+    
+    Ancestral File is a computerized collection of genealogies that links 
+    families into pedigrees, showing ancestors and descendants. An Ancestral
+    File Number was assigned to every record that was published in Ancestral
+    File.
+    
+    See https://www.familysearch.org/wiki/en/Ancestral_File for more.
+
+...

--- a/specification/terms/RFN
+++ b/specification/terms/RFN
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/RFN
+
+descriptions:
+  - Record File Number
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the 
+    https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's RFN structure.
+
+    GEDCOM versions 5.0 through 5.5.1 had a notion of a "registered resource
+    identifier". The registration process was never widely followed and ceased
+    being used in the early 2000s. URLs beginning
+    https://gedcom.io/terms/v7/RFN are placeholders for such "registered
+    resource identifiers", which may or may not have been registered and hence
+    may or may not be a unique resource identifier.
+    
+    The fragment identifer of this URI (the part after the #) is the
+    registered resource identifier; the payload of the EXID is the record
+    identifier within that resource. If there is no fragment identifier,
+    the EXID may represent either a registered number of a submitter of
+    Ancestral File data (see https://gedcom.io/terms/v7/AFN) or may have been
+    created by a user omitting to indicate the resource in 5.5.1 or earlier.
+    
+    It is recommend that the 5.5.1 structure
+    
+        2 RFN xyz:123abc
+    
+    be converted to 7.0 structures
+    
+        2 EXID xyz
+        3 TYPE https://gedcom.io/terms/v7/RFN#123abc
+
+...

--- a/specification/terms/RIN
+++ b/specification/terms/RIN
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+type: legacy
+
+uri: https://gedcom.io/terms/v7/RIN
+
+descriptions:
+  - Record ID Number
+  - |
+    This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
+    GEDCOM 7.0 and beyond. It is intended for use as the
+    https://gedcom.io/terms/v7/TYPE of an 
+    https://gedcom.io/terms/v7/EXID replacing 5.5.1's RIN structure.
+
+    GEDCOM 5.5 and 5.5.1 defined RIN as follows:
+    
+    > A unique record identification number assigned to the record by the
+    > source system. This number is intended to serve as a more sure means of
+    > identification of a record for reconciling differences in data between
+    > two interfacing systems.
+    
+    URLs beginning https://gedcom.io/terms/v7/RIN are used to represent
+    such source systems if they did not have a dedicated URI. The fragment
+    identifer of this URI (the part after the #) represents how the source
+    system was identified in the 5.5 or 5.5.1 file's header; the payload of the
+    EXID is the record identifier within that resource. If there is no fragment
+    identifier, the EXID was an RIN given without a source system identifier.
+    
+    It is recommend that the 5.5.1 structure
+    
+        2 RIN 123abc
+    
+    in a file with HEAD.SOUR line value "XYZ"
+    be converted to 7.0 structures
+    
+        2 EXID 123abc
+        3 TYPE https://gedcom.io/terms/v7/RIN#XYZ
+
+...


### PR DESCRIPTION
As described by #63 we want to have generic URIs for converting removed 5.5.1 identifiers to 7.0 EXIDs.

Once we converge on the text we want to serve at these URLS, I'll likely move these files to another folder and update the scripts in `build/` to copy them to `extracted-files/tags/` for us.