### PR TITLE
Fix missing diacritic and spelling mistake

### DIFF
--- a/specification/gedcom-06-calendars.md
+++ b/specification/gedcom-06-calendars.md
@@ -72,7 +72,7 @@ Permitted months are
 |`MESS`|Messidor           |
 |`THER`|Thermidor          |
 |`FRUC`|Fructidor          |
-|`COMP`|Jour Complementairs|
+|`COMP`|Jour Complémentairs|
 
 No epoch marker is permitted in this calendar.
 

--- a/specification/gedcom-06-calendars.md
+++ b/specification/gedcom-06-calendars.md
@@ -58,21 +58,21 @@ The French Republican calendar or French Revolutionary calendar are the names gi
 
 Permitted months are
 
-|Code  |Name               |
-|:-----|:------------------|
-|`VEND`|Vendémiaire        |
-|`BRUM`|Brumaire           |
-|`FRIM`|Frimaire           |
-|`NIVO`|Nivôse             |
-|`PLUV`|Pluviôse           |
-|`VENT`|Ventôse            |
-|`GERM`|Germinal           |
-|`FLOR`|Floréal            |
-|`PRAI`|Prairial           |
-|`MESS`|Messidor           |
-|`THER`|Thermidor          |
-|`FRUC`|Fructidor          |
-|`COMP`|Jour Complémentairs|
+|Code  |Name                |
+|:-----|:-------------------|
+|`VEND`|Vendémiaire         |
+|`BRUM`|Brumaire            |
+|`FRIM`|Frimaire            |
+|`NIVO`|Nivôse              |
+|`PLUV`|Pluviôse            |
+|`VENT`|Ventôse             |
+|`GERM`|Germinal            |
+|`FLOR`|Floréal             |
+|`PRAI`|Prairial            |
+|`MESS`|Messidor            |
+|`THER`|Thermidor           |
+|`FRUC`|Fructidor           |
+|`COMP`|Jour Complémentaires|
 
 No epoch marker is permitted in this calendar.
 


### PR DESCRIPTION
Fix missing diacritic in French Republican Calendar month definition. 
Jour complementaire --> Jour complémentaires
See [https://en.wikipedia.org/wiki/Sansculottides]( https://en.wikipedia.org/wiki/Sansculottides).