### PR TITLE
Limit days and years by calendar

### DIFF
--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -88,7 +88,9 @@ epoch   = %s"BCE" / extTag ; constrained by calendar
 
 In addition to the constraints above:
 
-- The allowable `month`s and `epoch`s are determined by the `calendar`.
+- The allowable `day`s, `month`s, `year`s, and `epoch`s are determined by the `calendar`.
+    All known calendars restrict `day` to be between 1 and a month-specific maximum.
+    The largest known maximum is 36, and most months in most calendars have a lower maximum.
 - No calendar names, months, or epochs match `dateRestrict`.
 - Extension calendars (those with `extTag` for their `calendar`) must use `extTag`, not `stdTag`, for months.
 


### PR DESCRIPTION
Previously we said "the allowable `month`s and `epoch`s are determined by the `calendar`."
Now we say "the allowable `day`s, `month`s, `year`s, and `epoch`s are determined by the `calendar`."
Also a note about the range of days in known calendars.

See #113 for more.