### PR TITLE
Fix several spec bugs

### DIFF
--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -1828,7 +1828,7 @@ The following represents Baltimore, a city that is not within a county.
 
 #### `FORM` (Format) `g7:HEAD-PLAC-FORM`
 
-Any `PLAC` with no `FORM` shall be treated as if it has this `FORM`.
+Any `PLAC` with no `FORM` shall be treated as if it has this [`FORM`](#PLAC-FORM).
 
 #### `GEDC` (GEDCOM) `g7:GEDC`
 
@@ -2801,7 +2801,7 @@ See [Events] and [Attributes].
 
 ### `SOUR`.`EVEN` {.unlisted .unnumbered #enum-SOUR.EVEN}
 
-An event- or attribute-type tag names.
+An event- or attribute-type tag name.
 See [Events] and [Attributes].
 
 ### `MEDI` {.unlisted .unnumbered #enum-MEDI}

--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -1828,7 +1828,7 @@ The following represents Baltimore, a city that is not within a county.
 
 #### `FORM` (Format) `g7:HEAD-PLAC-FORM`
 
-Any `PLAC` with no `FORM` shall be treated as if it has this [`FORM`](#PLAC-FORM).
+Any `PLAC` with no [`FORM`](#PLAC-FORM) shall be treated as if it has this [`FORM`](#PLAC-FORM).
 
 #### `GEDC` (GEDCOM) `g7:GEDC`
 
@@ -2648,7 +2648,7 @@ the resulting set of files might be presented as follows:
 1 FILE media/original.mp3
 2 FORM audio/mp3
 2 TRAN media/derived.oga
-3 FORM auto/ogg
+3 FORM audio/ogg
 2 TRAN media/transcript.vtt
 3 FORM text/vtt
 ```


### PR DESCRIPTION
This PR fixes several bugs:
* The text in g7:HEAD-PLAC-FORM was incorrectly linking to g7:FORM instead of g7:PLAC-FORM
* Incorrect media type as reported by @fisharebest in https://github.com/FamilySearch/GEDCOM.io/pull/36
* Grammatical nit