### PR TITLE
Revert name part cardinality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
-# Version 7.08
+# Version 7.0.9
+
+- Undo 7.0.8's reversion of undocumented and unexplained use of `{0:M}` cardinality for name parts, as it has been used by some applications. Added note explaining that repeated name parts may have meaning to the user.
+
+
+
+# Version 7.0.8
 
 - Revert undocumented and unexplained use of `{0:M}` cardinality for name parts in 7.0.0 through 7.0.7
 
@@ -17,7 +23,7 @@
 - Various grammar and spelling corrections
 
 
-# Version 7.07
+# Version 7.0.7
 
 - Update the `DateValue` and `DatePeriod` ABNF to match the textual statement that these can be empty.
 

--- a/extracted-files/cardinalities.tsv
+++ b/extracted-files/cardinalities.tsv
@@ -507,8 +507,8 @@ https://gedcom.io/terms/v7/FILE-TRAN	https://gedcom.io/terms/v7/FORM	{1:1}
 https://gedcom.io/terms/v7/PLAC	https://gedcom.io/terms/v7/PLAC-FORM	{0:1}
 https://gedcom.io/terms/v7/HEAD-PLAC	https://gedcom.io/terms/v7/HEAD-PLAC-FORM	{1:1}
 HEAD pseudostructure	https://gedcom.io/terms/v7/GEDC	{1:1}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/GIVN	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/GIVN	{0:1}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/GIVN	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/GIVN	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/GRAD	{0:M}
 https://gedcom.io/terms/v7/CROP	https://gedcom.io/terms/v7/HEIGHT	{0:1}
 https://gedcom.io/terms/v7/ANUL	https://gedcom.io/terms/v7/HUSB	{0:1}
@@ -561,8 +561,8 @@ https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NATI	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NATU	{0:M}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/FAM-NCHI	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/INDI-NCHI	{0:M}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NICK	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NICK	{0:1}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NICK	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NICK	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NMR	{0:M}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/NO	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NO	{0:M}
@@ -640,10 +640,10 @@ https://gedcom.io/terms/v7/record-OBJE	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/record-REPO	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/record-SOUR	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/record-SUBM	https://gedcom.io/terms/v7/NOTE	{0:M}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NPFX	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NPFX	{0:1}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NSFX	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NSFX	{0:1}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NPFX	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NPFX	{0:M}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/NSFX	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NSFX	{0:M}
 https://gedcom.io/terms/v7/ADOP	https://gedcom.io/terms/v7/OBJE	{0:M}
 https://gedcom.io/terms/v7/ANUL	https://gedcom.io/terms/v7/OBJE	{0:M}
 https://gedcom.io/terms/v7/BAPM	https://gedcom.io/terms/v7/OBJE	{0:M}
@@ -1153,8 +1153,8 @@ https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SOUR	{0:M}
 https://gedcom.io/terms/v7/record-OBJE	https://gedcom.io/terms/v7/SOUR	{0:M}
 https://gedcom.io/terms/v7/record-SNOTE	https://gedcom.io/terms/v7/SOUR	{0:M}
 HEAD pseudostructure	https://gedcom.io/terms/v7/HEAD-SOUR	{0:1}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SPFX	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/SPFX	{0:1}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SPFX	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/SPFX	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SSN	{0:M}
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/STAE	{0:1}
 https://gedcom.io/terms/v7/BAPL	https://gedcom.io/terms/v7/ord-STAT	{0:1}
@@ -1167,8 +1167,8 @@ https://gedcom.io/terms/v7/INDI-FAMC	https://gedcom.io/terms/v7/FAMC-STAT	{0:1}
 HEAD pseudostructure	https://gedcom.io/terms/v7/SUBM	{0:1}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/SUBM	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SUBM	{0:M}
-https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SURN	{0:1}
-https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/SURN	{0:1}
+https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SURN	{0:M}
+https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/SURN	{0:M}
 https://gedcom.io/terms/v7/SCHMA	https://gedcom.io/terms/v7/TAG	{0:M}
 https://gedcom.io/terms/v7/BAPL	https://gedcom.io/terms/v7/TEMP	{0:1}
 https://gedcom.io/terms/v7/CONL	https://gedcom.io/terms/v7/TEMP	{0:1}

--- a/extracted-files/grammar.gedstruct
+++ b/extracted-files/grammar.gedstruct
@@ -571,12 +571,12 @@ n SNOTE @<XREF:SNOTE>@                     {1:1}  g7:SNOTE
 
 
 PERSONAL_NAME_PIECES :=
-n NPFX <Text>                              {0:1}  g7:NPFX
-n GIVN <Text>                              {0:1}  g7:GIVN
-n NICK <Text>                              {0:1}  g7:NICK
-n SPFX <Text>                              {0:1}  g7:SPFX
-n SURN <Text>                              {0:1}  g7:SURN
-n NSFX <Text>                              {0:1}  g7:NSFX
+n NPFX <Text>                              {0:M}  g7:NPFX
+n GIVN <Text>                              {0:M}  g7:GIVN
+n NICK <Text>                              {0:M}  g7:NICK
+n SPFX <Text>                              {0:M}  g7:SPFX
+n SURN <Text>                              {0:M}  g7:SURN
+n NSFX <Text>                              {0:M}  g7:NSFX
 
 
 PERSONAL_NAME_STRUCTURE :=

--- a/extracted-files/tags/GIVN
+++ b/extracted-files/tags/GIVN
@@ -15,6 +15,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/extracted-files/tags/INDI-NAME
+++ b/extracted-files/tags/INDI-NAME
@@ -38,17 +38,17 @@ descriptions:
 payload: https://gedcom.io/terms/v7/type-Name
 
 substructures:
-  "https://gedcom.io/terms/v7/GIVN": "{0:1}"
+  "https://gedcom.io/terms/v7/GIVN": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TYPE": "{0:1}"
-  "https://gedcom.io/terms/v7/NICK": "{0:1}"
+  "https://gedcom.io/terms/v7/NICK": "{0:M}"
   "https://gedcom.io/terms/v7/NOTE": "{0:M}"
-  "https://gedcom.io/terms/v7/NPFX": "{0:1}"
-  "https://gedcom.io/terms/v7/NSFX": "{0:1}"
+  "https://gedcom.io/terms/v7/NPFX": "{0:M}"
+  "https://gedcom.io/terms/v7/NSFX": "{0:M}"
   "https://gedcom.io/terms/v7/SNOTE": "{0:M}"
   "https://gedcom.io/terms/v7/SOUR": "{0:M}"
-  "https://gedcom.io/terms/v7/SPFX": "{0:1}"
-  "https://gedcom.io/terms/v7/SURN": "{0:1}"
+  "https://gedcom.io/terms/v7/SPFX": "{0:M}"
+  "https://gedcom.io/terms/v7/SURN": "{0:M}"
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"

--- a/extracted-files/tags/NAME-TRAN
+++ b/extracted-files/tags/NAME-TRAN
@@ -43,13 +43,13 @@ descriptions:
 payload: https://gedcom.io/terms/v7/type-Name
 
 substructures:
-  "https://gedcom.io/terms/v7/GIVN": "{0:1}"
+  "https://gedcom.io/terms/v7/GIVN": "{0:M}"
   "https://gedcom.io/terms/v7/LANG": "{1:1}"
-  "https://gedcom.io/terms/v7/NICK": "{0:1}"
-  "https://gedcom.io/terms/v7/NPFX": "{0:1}"
-  "https://gedcom.io/terms/v7/NSFX": "{0:1}"
-  "https://gedcom.io/terms/v7/SPFX": "{0:1}"
-  "https://gedcom.io/terms/v7/SURN": "{0:1}"
+  "https://gedcom.io/terms/v7/NICK": "{0:M}"
+  "https://gedcom.io/terms/v7/NPFX": "{0:M}"
+  "https://gedcom.io/terms/v7/NSFX": "{0:M}"
+  "https://gedcom.io/terms/v7/SPFX": "{0:M}"
+  "https://gedcom.io/terms/v7/SURN": "{0:M}"
 
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"

--- a/extracted-files/tags/NICK
+++ b/extracted-files/tags/NICK
@@ -16,6 +16,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/extracted-files/tags/NPFX
+++ b/extracted-files/tags/NPFX
@@ -16,6 +16,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/extracted-files/tags/NSFX
+++ b/extracted-files/tags/NSFX
@@ -16,6 +16,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/extracted-files/tags/SPFX
+++ b/extracted-files/tags/SPFX
@@ -15,6 +15,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/extracted-files/tags/SURN
+++ b/extracted-files/tags/SURN
@@ -15,6 +15,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: []
 
 superstructures:
-  "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
-  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:1}"
+  "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
 ...

--- a/specification/gedcom-00-introduction.md
+++ b/specification/gedcom-00-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: The FamilySearch GEDCOM Specification
-subtitle: 7.0.8
+subtitle: 7.0.9
 email: GEDCOM@FamilySearch.org
 copyright: |
     :::{style="page-break-after: always;page-break-before: always;"}

--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -1024,12 +1024,12 @@ A `NOTE_STRUCTURE` can contain a `SOURCE_CITATION`, which in turn can contain a 
 #### `PERSONAL_NAME_PIECES` :=
 
 ```gedstruct
-n NPFX <Text>                              {0:1}  g7:NPFX
-n GIVN <Text>                              {0:1}  g7:GIVN
-n NICK <Text>                              {0:1}  g7:NICK
-n SPFX <Text>                              {0:1}  g7:SPFX
-n SURN <Text>                              {0:1}  g7:SURN
-n NSFX <Text>                              {0:1}  g7:NSFX
+n NPFX <Text>                              {0:M}  g7:NPFX
+n GIVN <Text>                              {0:M}  g7:GIVN
+n NICK <Text>                              {0:M}  g7:NICK
+n SPFX <Text>                              {0:M}  g7:SPFX
+n SURN <Text>                              {0:M}  g7:SURN
+n NSFX <Text>                              {0:M}  g7:NSFX
 ```
 
 Optional isolated name parts; see `PERSONAL_NAME_STRUCTURE` for more.
@@ -1046,16 +1046,9 @@ Optional isolated name parts; see `PERSONAL_NAME_STRUCTURE` for more.
 ```
 :::
 
-Names may have multiple parts that fit in the same piece; it is recommended that they appear in the same order in a piece structure as they do in the piece's superstructure.
-
-:::example
-```gedcom
-1 NAME William "Bill" Edward /Hernandez Martinez/
-2 GIVN William Edward
-2 NICK Bill
-2 SURN Hernandez Martinez
-```
-:::
+This specification does not define how the meaning of multiple parts with the same tag differs from the meaning of a single part with a concatenated larger payload.
+However, some applications allow the user to chose whether to combine or split name parts, meaning the tag quantity it should be treated as expressing at least a user preference.
+Even when multiple `SURN` tags are used, the `PersonalName` datatype identifies a single surname substring between its slashes.
 
 #### `PERSONAL_NAME_STRUCTURE` :=
 

--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -1047,7 +1047,7 @@ Optional isolated name parts; see `PERSONAL_NAME_STRUCTURE` for more.
 :::
 
 This specification does not define how the meaning of multiple parts with the same tag differs from the meaning of a single part with a concatenated larger payload.
-However, some applications allow the user to chose whether to combine or split name parts, meaning the tag quantity it should be treated as expressing at least a user preference.
+However, some applications allow the user to chose whether to combine or split name parts, meaning the tag quantity should be treated as expressing at least a user preference.
 Even when multiple `SURN` tags are used, the `PersonalName` datatype identifies a single surname substring between its slashes.
 
 #### `PERSONAL_NAME_STRUCTURE` :=


### PR DESCRIPTION
Per #152, the belief that we could change name cardinalities in a patch was based on a misapprehension of their use in existing applications. This PR proposes reverting that with a new 7.0.9 release.