### PR TITLE
Fix spelling of romaji

### DIFF
--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -2595,7 +2595,7 @@ See also `PLAC`.
 :::example
 The following presents a place
 in Japanese
-with a romanji transliteration
+with a romaji transliteration
 and English translation
 
 ```gedcom


### PR DESCRIPTION
"romanji" is incorrect, the word is [romaji](https://en.wikipedia.org/wiki/Romanization_of_Japanese).

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>