### PR TITLE
Add FamilySearch EXID types

### DIFF
--- a/exid-types.json
+++ b/exid-types.json
@@ -24,5 +24,45 @@
     "change-controller": "FamilySearch",
     "fragment": "Resource ID",
     "reference": "https://gedcom.io/migrate/#afn-rfn-rin"
+  },
+  {
+    "label": "FamilySearch Memory ID",
+    "type": "https://gedcom.io/exid-type/FamilySearch-MemoryId",
+    "description": "FamilySearch Memory ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FamilySearch",
+    "reference": "https://gedcom.io/exid-type/FamilySearch-MemoryId"
+  },
+  {
+    "label": "FamilySearch Person ID",
+    "type": "https://gedcom.io/exid-type/FamilySearch-PersonId",
+    "description": "FamilySearch Person ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FamilySearch",
+    "reference": "https://gedcom.io/exid-type/FamilySearch-PersonId"
+  },
+  {
+    "label": "FamilySearch Place ID",
+    "type": "https://gedcom.io/exid-type/FamilySearch-PlaceId",
+    "description": "FamilySearch Place ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FamilySearch",
+    "reference": "https://gedcom.io/exid-type/FamilySearch-PlaceId"
+  },
+  {
+    "label": "FamilySearch Source Description ID",
+    "type": "https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId",
+    "description": "FamilySearch Source Description ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FamilySearch",
+    "reference": "https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId"
+  },
+  {
+    "label": "FamilySearch User ID",
+    "type": "https://gedcom.io/exid-type/FamilySearch-UserId",
+    "description": "FamilySearch User ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FamilySearch",
+    "reference": "https://gedcom.io/exid-type/FamilySearch-UserId"
   }
 ]


### PR DESCRIPTION
https://github.com/FamilySearch/GEDCOM.io/pull/43 added FamilySearch
EXID types to gedcom.io but neglected to add them to the exid-types.json
file in the GEDCOM repository.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>