### PR TITLE
rename `type: legacy` to `type: uri`

### DIFF
--- a/specification/terms/AFN
+++ b/specification/terms/AFN
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-type: legacy
+type: uri
 
 uri: https://gedcom.io/terms/v7/AFN
 

--- a/specification/terms/RFN
+++ b/specification/terms/RFN
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-type: legacy
+type: uri
 
 uri: https://gedcom.io/terms/v7/RFN
 

--- a/specification/terms/RIN
+++ b/specification/terms/RIN
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-type: legacy
+type: uri
 
 uri: https://gedcom.io/terms/v7/RIN
 


### PR DESCRIPTION
A simple rename in three YAML files; see also [PR #53 on the GEDCOM.io repo](https://github.com/FamilySearch/GEDCOM.io/pull/53)