### PR TITLE
Extension structure meaning depends on superstructure type

### DIFF
--- a/specification/gedcom-01-serialization.md
+++ b/specification/gedcom-01-serialization.md
@@ -430,7 +430,7 @@ and a system importing one may export it as the other without change of meaning.
 :::
 
 An extension tag that is not given a URI in the schema structure is called an **undocumented extension tag**.
-The meaning of an undocumented extension tag is identified by its superstructure type and tag.
+The meaning of an undocumented extension tag is identified by its superstructure type and its tag.
 
 
 ### Requirements and Recommendations

--- a/specification/gedcom-01-serialization.md
+++ b/specification/gedcom-01-serialization.md
@@ -403,7 +403,7 @@ defines the following tags
 | `_MEMBER` | `http://xmlns.com/foaf/0.1/member` |
 :::
 
-The meaning of a documented extension tag is identified by its URI, not its tag.
+The meaning of a documented extension tag is identified by its superstructure type and URI, not its tag.
 Documented extension tags can be changed freely by modifying the schema,
 though it is recommended that documented extension tags not be changed.
 However, a tag change may be necessary if a product picks the same tags for URIs that another product uses for different URIs.
@@ -430,7 +430,7 @@ and a system importing one may export it as the other without change of meaning.
 :::
 
 An extension tag that is not given a URI in the schema structure is called an **undocumented extension tag**.
-The meaning of an undocumented extension tag is identified by its tag.
+The meaning of an undocumented extension tag is identified by its superstructure type and tag.
 
 
 ### Requirements and Recommendations

--- a/specification/gedcom-01-serialization.md
+++ b/specification/gedcom-01-serialization.md
@@ -403,7 +403,7 @@ defines the following tags
 | `_MEMBER` | `http://xmlns.com/foaf/0.1/member` |
 :::
 
-The meaning of a documented extension tag is identified by its superstructure type and URI, not its tag.
+The meaning of a documented extension tag is identified by its superstructure type and its URI, not its tag.
 Documented extension tags can be changed freely by modifying the schema,
 though it is recommended that documented extension tags not be changed.
 However, a tag change may be necessary if a product picks the same tags for URIs that another product uses for different URIs.


### PR DESCRIPTION
As discussed in issue #180, practice is that extension tags like `_LOC` means different things under different superstructures, but the current text does not acknowledge that. This PR adds that acknowledgement.