### PR TITLE
Consistency between data type vs datatype

### DIFF
--- a/specification/gedcom-01-serialization.md
+++ b/specification/gedcom-01-serialization.md
@@ -155,8 +155,8 @@ The **line value** matches production `LineVal` and encodes the structure's payl
 Line value content is sufficient to distinguish between pointers and line strings.
 Pointers are encoded as the cross-reference identifier of the pointed-to structure.
 Each non-pointer payload may be encoded in 1 or more line strings (line continuations encode multi-line payloads in several line strings).
-The exact encoding of non-pointer payloads is dependent on the datatype of the payload, as determined by the structure type.
-The datatype of non-pointer payloads cannot be fully determined by line value content alone.
+The exact encoding of non-pointer payloads is dependent on the data type of the payload, as determined by the structure type.
+The data type of non-pointer payloads cannot be fully determined by line value content alone.
 
 Note that production `LineVal` does not match the empty string.
 Because empty payloads and missing payloads are considered equivalent,
@@ -295,7 +295,7 @@ In the following
 - Both uses of `_LOC` are tagged extension structures, as is `_POP`.
 - `_LOC`.`NAME` and `_LOC`.`NAME`.`DATE` are both extension-defined substructures. Their meaning is defined by the specification defining `_LOC`.
 - `_POP`.`DATE` is an extension-defined substructure. Its meaning is defined by the specification defining `_POP`.
-- Even though both `DATE`s appear to have `g7:type-DATE` payloads, we can't know that is the intended datatype without consulting the defining specifications of `_LOC` and `_POP`, respectively. The first might be a `g7:type-DATE#period` and the second a `g7:type-DATE#exact`, for example.
+- Even though both `DATE`s appear to have `g7:type-DATE` payloads, we can't know that is the intended data type without consulting the defining specifications of `_LOC` and `_POP`, respectively. The first might be a `g7:type-DATE#period` and the second a `g7:type-DATE#exact`, for example.
 :::
 
 If an extension-defined substructure has a tag that is also used by one or more standard structures, its meaning and payload type should match at least one of those standard structure types.
@@ -509,7 +509,7 @@ In general, removed data should result in removed structures.
 
 Pointers to a removed structure should be replaced with `voidPtr`s.
 
-If removal of a structure makes the superstructure invalid because the superstructure required the substructure, the structure should instead be retained and have its payload changed to a `voidPtr` if a pointer, or to a datatype-appropriate empty value if a non-pointer.
+If removal of a structure makes the superstructure invalid because the superstructure required the substructure, the structure should instead be retained and have its payload changed to a `voidPtr` if a pointer, or to a data type-appropriate empty value if a non-pointer.
 
 If removing a structure leaves its superstructure with no payload and no substructures, the superstructure should also be removed.
 

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -1,7 +1,7 @@
 # Data types {#datatypes}
 
 Every line value (with any continuation pseudo-structures) is a string.
-However, those strings can encode 1 of several conceptual datatypes.
+However, those strings can encode 1 of several conceptual data types.
 
 ## Text
 
@@ -14,7 +14,7 @@ anychar = %x09-10FFFF ; but not banned, as with all ABNF rules
 Text    = *anychar
 ```
 
-The URI for the `Text` datatype is `xsd:string`.
+The URI for the `Text` data type is `xsd:string`.
 
 ## Integer
 
@@ -28,7 +28,7 @@ Integer = 1*digit
 
 Negative integers are not supported by this specification.
 
-The URI for the `Integer` datatype is `xsd:nonNegativeInteger`.
+The URI for the `Integer` data type is `xsd:nonNegativeInteger`.
 
 ## Enumeration
 
@@ -47,14 +47,14 @@ and have their URI defined by the schema.
 Each enumeration value has a distinct meaning
 as identified by its corresponding URI.
 
-The URI for the `Enum` datatype is `g7:type-Enum`.
+The URI for the `Enum` data type is `g7:type-Enum`.
 
 ## Date
 
 The date formats defined in this specification
 include the ability to store approximate dates, date periods, and dates expressed in different calendars.
 
-Technically, there are 3 distinct date datatypes:
+Technically, there are 3 distinct date data types:
 
 - `DateValue` is a generic type that can express many kinds of dates.
 - `DateExact` is used for timestamps and other fully-known dates.
@@ -139,11 +139,11 @@ The following is an appropriate way to handle a missing year
 :::
 :::
 
-The URI for the `DateValue` datatype is `g7:type-Date`.
+The URI for the `DateValue` data type is `g7:type-Date`.
 
-The URI for the `DateExact` datatype is `g7:type-Date#exact`.
+The URI for the `DateExact` data type is `g7:type-Date#exact`.
 
-The URI for the `DatePeriod` datatype is `g7:type-Date#period`.
+The URI for the `DatePeriod` data type is `g7:type-Date#period`.
 
 ## Time
 
@@ -164,7 +164,7 @@ fraction = 1*digit
 The above grammar prohibits end-of-day instant `24:00:00` and leap-seconds. It allows both `02:50` and `2:50` as the same time.
 :::
 
-The URI for the `Time` datatype is `g7:type-Time`.
+The URI for the `Time` data type is `g7:type-Time`.
 
 ## Age
 
@@ -209,13 +209,13 @@ Versions 5.5 and 5.5.1 allowed a few specific phrases inside `Age` payloads.
 Age phrases were moved to the `PHRASE` substructure in 7.0.
 :::
 
-The URI for the `Age` datatype is `g7:type-Age`.
+The URI for the `Age` data type is `g7:type-Age`.
 
 
 ## List
 
-A list is a meta-syntax representing a sequence of values with another datatype.
-Two list datatypes are used in this document: List:Text and List:Enum.
+A list is a meta-syntax representing a sequence of values with another data type.
+Two list data types are used in this document: List:Text and List:Enum.
 Lists are serialized in a comma-separated form, delimited by a comma (U+002C `,`) and any number of spaces (U+0020) between each item.
 It is recommended that a comma-space pair (U+002C U+0020) be used as the delimiter.
 
@@ -238,9 +238,9 @@ A `List:Text` with value "`, , one, more,`" has 5 `Text`-type values: 2 empty st
 
 There is no escaping mechanism to allow lists of entries that begin or end with spaces or that contain comma characters.
 
-The URI for the `List:Text` datatype is `g7:type-List#Text`.
+The URI for the `List:Text` data type is `g7:type-List#Text`.
 
-The URI for the `List:Enum` datatype is `g7:type-List#Enum`.
+The URI for the `List:Enum` data type is `g7:type-List#Enum`.
 
 
 ## Personal Name
@@ -258,21 +258,21 @@ nameStr      = 1*nameChar
 The character U+002F (`/`, slash or solidus) has special meaning in a personal name, being used to delimit the portion of the name that most closely matches the concept of a surname, family name, or the like.
 This specification does not provide any standard way of representing names that contain U+002F.
 
-The URI for the `PersonalName` datatype is `g7:type-Name`.
+The URI for the `PersonalName` data type is `g7:type-Name`.
 
 ## Language
 
-The language datatype represents a human language or family of related languages, as defined in [BCP 46](https://www.rfc-editor.org/info/bcp47).
+The language data type represents a human language or family of related languages, as defined in [BCP 46](https://www.rfc-editor.org/info/bcp47).
 It consists of a sequence of language subtags separated by hyphens,
 where language subtags are [registered by the IANA](https://www.iana.org/assignments/language-subtag-registry).
 
 The ABNF grammar for language tags is given in BCP 47, section 2.1, production `Language-Tag`.
 
-The URI for the `Language` datatype is `xsd:Language`.
+The URI for the `Language` data type is `xsd:Language`.
 
 ## Media Type
 
-The media type datatype represents the encoding of information in bytes or characters, as defined in [RFC 2045](https://www.rfc-editor.org/info/rfc2045) and [registered by the IANA](http://www.iana.org/assignments/media-types/).
+The media type data type represents the encoding of information in bytes or characters, as defined in [RFC 2045](https://www.rfc-editor.org/info/rfc2045) and [registered by the IANA](http://www.iana.org/assignments/media-types/).
 
 The official grammar for media type is given in RFC 2045, section 5.1.
 However, that document does not give stand-alone ABNF, instead referring to registration rules and describing some components in English.
@@ -295,15 +295,15 @@ mt-qtext     = %x09-0A / %x20-21 / %x23-5B / %x5D-7E ; not CR "\
 mt-qpair     = "\" %x09-7E
 ```
 
-The URI for the `MediaType` datatype is `dcat:mediaType`.
+The URI for the `MediaType` data type is `dcat:mediaType`.
 
 ## Special
 
-The special datatype is a string conforming to a case-specific standard or constraints. The constraints on each special datatype instance are either unique to that structure type or are not simply expressed.
+The special data type is a string conforming to a case-specific standard or constraints. The constraints on each special data type instance are either unique to that structure type or are not simply expressed.
 For example, the payload of an `IDNO` structure may obey different rules for each possible `TYPE` substructure.
 
-Each special datatype is distinct.
-The URI for the generic datatype subsuming all `Special` datatypes is `xsd:string` (the same as the `Text` datatype).
+Each special data type is distinct.
+The URI for the generic data type subsuming all `Special` data types is `xsd:string` (the same as the `Text` data type).
 
 ```abnf
 Special = Text

--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -69,7 +69,7 @@ The intent of this metasyntax is to resemble the line encoding of allowable stru
     - An optional payload descriptor; if present this is 1 of the following:
         
         - `@<XREF:`tag`>@` means a pointer to a structure with this cross-reference template; `@VOID@` is also permitted.
-        - `<`datatype`>` means a non-pointer payload, as described in [Data types](#datatypes). If the datatype allows the empty string, the payload may be omitted.
+        - `<`data type`>` means a non-pointer payload, as described in [Data types](#datatypes). If the data type allows the empty string, the payload may be omitted.
         - `[`text`|<NULL>]` means the payload is optional but if present must be the given text.
         
         If there is a payload descriptor, a payload that matches the payload is required of the described structure unless the descriptor says the payload is optional.
@@ -1048,7 +1048,7 @@ Optional isolated name parts; see `PERSONAL_NAME_STRUCTURE` for more.
 
 This specification does not define how the meaning of multiple parts with the same tag differs from the meaning of a single part with a concatenated larger payload.
 However, some applications allow the user to chose whether to combine or split name parts, meaning the tag quantity should be treated as expressing at least a user preference.
-Even when multiple `SURN` tags are used, the `PersonalName` datatype identifies a single surname substring between its slashes.
+Even when multiple `SURN` tags are used, the `PersonalName` data type identifies a single surname substring between its slashes.
 
 #### `PERSONAL_NAME_STRUCTURE` :=
 
@@ -2199,7 +2199,7 @@ See ITU standards [E.123](https://www.itu.int/rec/T-REC-E.123) and [E.164](https
 
 #### `PHRASE` (Phrase) `g7:PHRASE`
 
-Textual information that cannot be expressed in the superstructure due to the limitations of its datatype.
+Textual information that cannot be expressed in the superstructure due to the limitations of its data type.
 A `PHRASE` may restate information contained in the superstructure, but doing so is not recommended unless it is needed for clarity.
 
 :::example


### PR DESCRIPTION
Both were used throughout.  This change provides consistency
by only using "data type", which appears in dictionaries,
unlike "datatype".

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>