### PR TITLE
Use [ ] instead of "" to denote optional payloads

### DIFF
--- a/extracted-files/grammar.abnf
+++ b/extracted-files/grammar.abnf
@@ -59,11 +59,11 @@ Enum    = Tag
 
 ; ------------- Date -------------
 
-DateValue   = date / DatePeriod / dateRange / dateApprox / ""
+DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
 DateExact   = day D month D year  ; in Gregorian calendar
-DatePeriod  = %s"FROM" D date [D %s"TO" D date]
-            / %s"TO" D date
-            / ""
+DatePeriod  = [ %s"TO" D date ]
+            / %s"FROM" D date [D %s"TO" D date]
+            ; note both DateValue and DatePeriod can be the empty string
 
 date        = [calendar D] [[day D] month D] year [D epoch]
 dateRange   = %s"BET" D date D %s"AND" D date
@@ -111,14 +111,14 @@ days    = Integer %x64    ; 21d
 
 ; ------------- List -------------
 
-List      = listItem *(listDelim listItem)
-listItem  = "" / nocommasp / nocommasp *nocomma nocommasp
+list      = listItem *(listDelim listItem)
+listItem  = nocommasp / nocommasp *nocomma nocommasp
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
 
-List-Text = List
-List-Enum = Enum *(listDelim Enum)
+List-Text = [ list ]               ; may be empty
+List-Enum = Enum *(listDelim Enum) ; must not be empty
 
 
 ; ------------- Personal Name -------------

--- a/extracted-files/grammar.abnf
+++ b/extracted-files/grammar.abnf
@@ -112,13 +112,13 @@ days    = Integer %x64    ; 21d
 ; ------------- List -------------
 
 list      = listItem *(listDelim listItem)
-listItem  = nocommasp / nocommasp *nocomma nocommasp
+listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
 
-List-Text = [ list ]               ; may be empty
-List-Enum = Enum *(listDelim Enum) ; must not be empty
+List-Text = list
+List-Enum = Enum *(listDelim Enum)
 
 
 ; ------------- Personal Name -------------

--- a/extracted-files/grammar.abnf
+++ b/extracted-files/grammar.abnf
@@ -62,7 +62,7 @@ Enum    = Tag
 DateValue   = [ date / DatePeriod / dateRange / dateApprox ]
 DateExact   = day D month D year  ; in Gregorian calendar
 DatePeriod  = [ %s"TO" D date ]
-            / %s"FROM" D date [D %s"TO" D date]
+            / %s"FROM" D date [ D %s"TO" D date ]
             ; note both DateValue and DatePeriod can be the empty string
 
 date        = [calendar D] [[day D] month D] year [D epoch]

--- a/extracted-files/grammar.abnf
+++ b/extracted-files/grammar.abnf
@@ -59,7 +59,7 @@ Enum    = Tag
 
 ; ------------- Date -------------
 
-DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
+DateValue   = [ date / DatePeriod / dateRange / dateApprox ]
 DateExact   = day D month D year  ; in Gregorian calendar
 DatePeriod  = [ %s"TO" D date ]
             / %s"FROM" D date [D %s"TO" D date]

--- a/extracted-files/grammar.abnf
+++ b/extracted-files/grammar.abnf
@@ -112,7 +112,7 @@ days    = Integer %x64    ; 21d
 ; ------------- List -------------
 
 list      = listItem *(listDelim listItem)
-listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
+listItem  = [ nocommasp / nocommasp *nocomma nocommasp ]
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF

--- a/extracted-files/tags/type-Date
+++ b/extracted-files/tags/type-Date
@@ -18,11 +18,11 @@ specification:
     -   DateExact is used for timestamps and other fully-known dates.
     -   DatePeriod is used to express time intervals that span multiple days.
     
-        DateValue   = date / DatePeriod / dateRange / dateApprox / ""
+        DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
         DateExact   = day D month D year  ; in Gregorian calendar
-        DatePeriod  = %s"FROM" D date [D %s"TO" D date]
-                    / %s"TO" D date
-                    / ""
+        DatePeriod  = [ %s"TO" D date ]
+                    / %s"FROM" D date [D %s"TO" D date]
+                    ; note both DateValue and DatePeriod can be the empty string
     
         date        = [calendar D] [[day D] month D] year [D epoch]
         dateRange   = %s"BET" D date D %s"AND" D date

--- a/extracted-files/tags/type-Date
+++ b/extracted-files/tags/type-Date
@@ -18,10 +18,10 @@ specification:
     -   DateExact is used for timestamps and other fully-known dates.
     -   DatePeriod is used to express time intervals that span multiple days.
     
-        DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
+        DateValue   = [ date / DatePeriod / dateRange / dateApprox ]
         DateExact   = day D month D year  ; in Gregorian calendar
         DatePeriod  = [ %s"TO" D date ]
-                    / %s"FROM" D date [D %s"TO" D date]
+                    / %s"FROM" D date [ D %s"TO" D date ]
                     ; note both DateValue and DatePeriod can be the empty string
     
         date        = [calendar D] [[day D] month D] year [D epoch]

--- a/extracted-files/tags/type-List
+++ b/extracted-files/tags/type-List
@@ -16,7 +16,7 @@ specification:
     delimiter.
     
         list      = listItem *(listDelim listItem)
-        listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
+        listItem  = [ nocommasp / nocommasp *nocomma nocommasp ]
         listDelim = *D "," *D
         nocomma   = %x09-2B / %x2D-10FFFF
         nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF

--- a/extracted-files/tags/type-List
+++ b/extracted-files/tags/type-List
@@ -16,13 +16,13 @@ specification:
     delimiter.
     
         list      = listItem *(listDelim listItem)
-        listItem  = nocommasp / nocommasp *nocomma nocommasp
+        listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
         listDelim = *D "," *D
         nocomma   = %x09-2B / %x2D-10FFFF
         nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
     
-        List-Text = [ list ]               ; may be empty
-        List-Enum = Enum *(listDelim Enum) ; must not be empty
+        List-Text = list
+        List-Enum = Enum *(listDelim Enum)
     
     If valid for the underlying type, empty strings may be included in a list
     by having no characters between delimiters.

--- a/extracted-files/tags/type-List
+++ b/extracted-files/tags/type-List
@@ -15,14 +15,14 @@ specification:
     recommended that a comma-space pair (U+002C U+0020) be used as the
     delimiter.
     
-        List      = listItem *(listDelim listItem)
-        listItem  = "" / nocommasp / nocommasp *nocomma nocommasp
+        list      = listItem *(listDelim listItem)
+        listItem  = nocommasp / nocommasp *nocomma nocommasp
         listDelim = *D "," *D
         nocomma   = %x09-2B / %x2D-10FFFF
         nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
     
-        List-Text = List
-        List-Enum = Enum *(listDelim Enum)
+        List-Text = [ list ]               ; may be empty
+        List-Enum = Enum *(listDelim Enum) ; must not be empty
     
     If valid for the underlying type, empty strings may be included in a list
     by having no characters between delimiters.

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -237,13 +237,13 @@ It is recommended that a comma-space pair (U+002C U+0020) be used as the delimit
 
 ```abnf
 list      = listItem *(listDelim listItem)
-listItem  = nocommasp / nocommasp *nocomma nocommasp
+listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
 
-List-Text = [ list ]               ; may be empty
-List-Enum = Enum *(listDelim Enum) ; must not be empty
+List-Text = list
+List-Enum = Enum *(listDelim Enum)
 ```
 
 If valid for the underlying type, empty strings may be included in a list by having no characters between delimiters.

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -78,10 +78,10 @@ Technically, there are 3 distinct date data types:
 
 
 ```abnf
-DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
+DateValue   = [ date / DatePeriod / dateRange / dateApprox ]
 DateExact   = day D month D year  ; in Gregorian calendar
 DatePeriod  = [ %s"TO" D date ]
-            / %s"FROM" D date [D %s"TO" D date]
+            / %s"FROM" D date [ D %s"TO" D date ]
             ; note both DateValue and DatePeriod can be the empty string
 
 date        = [calendar D] [[day D] month D] year [D epoch]
@@ -237,7 +237,7 @@ It is recommended that a comma-space pair (U+002C U+0020) be used as the delimit
 
 ```abnf
 list      = listItem *(listDelim listItem)
-listItem  = [ nocommasp ] / nocommasp *nocomma nocommasp ; may be empty
+listItem  = [ nocommasp / nocommasp *nocomma nocommasp ]
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -78,11 +78,11 @@ Technically, there are 3 distinct date data types:
 
 
 ```abnf
-DateValue   = date / DatePeriod / dateRange / dateApprox / ""
+DateValue   = [ date ] / DatePeriod / dateRange / dateApprox
 DateExact   = day D month D year  ; in Gregorian calendar
-DatePeriod  = %s"FROM" D date [D %s"TO" D date]
-            / %s"TO" D date
-            / ""
+DatePeriod  = [ %s"TO" D date ]
+            / %s"FROM" D date [D %s"TO" D date]
+            ; note both DateValue and DatePeriod can be the empty string
 
 date        = [calendar D] [[day D] month D] year [D epoch]
 dateRange   = %s"BET" D date D %s"AND" D date
@@ -236,14 +236,14 @@ Lists are serialized in a comma-separated form, delimited by a comma (U+002C `,`
 It is recommended that a comma-space pair (U+002C U+0020) be used as the delimiter.
 
 ```abnf
-List      = listItem *(listDelim listItem)
-listItem  = "" / nocommasp / nocommasp *nocomma nocommasp
+list      = listItem *(listDelim listItem)
+listItem  = nocommasp / nocommasp *nocomma nocommasp
 listDelim = *D "," *D
 nocomma   = %x09-2B / %x2D-10FFFF
 nocommasp = %x09-1D / %x21-2B / %x2D-10FFFF
 
-List-Text = List
-List-Enum = Enum *(listDelim Enum)
+List-Text = [ list ]               ; may be empty
+List-Enum = Enum *(listDelim Enum) ; must not be empty
 ```
 
 If valid for the underlying type, empty strings may be included in a list by having no characters between delimiters.


### PR DESCRIPTION
This was requested in #206 to support ABNF packages that fail to handle `""` correctly. It changes the form of the ABNF, but not its meaning.