### PR TITLE
Recommend using UTC where DateExact is used

### DIFF
--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -168,6 +168,7 @@ The URI for the `DatePeriod` data type is `g7:type-Date#period`.
 Time is represented on a 24-hour clock (for example, 23:00 rather than 11:00 PM).
 It may be represented either in event-local time or in Coordinated Universal Time (UTC).
 UTC is indicated by including a `Z` (U+005A) after the time value; event-local time is indicated by its absence.
+When a time is used together with a `DateExact`, it is recommended that UTC time be used rather than event-local time.
 
 ```abnf
 Time     =  hour ":" minute [":" second ["." fraction]] [%s"Z"]


### PR DESCRIPTION
See #168 for more discussion.   Briefly, using event-local time as currently allowed results in a non-exact date due to ambiguous time zones.  While we cannot disallow this without a breaking change, we can add a recommendation that will help.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>