### PR TITLE
Permit enums to begin with a digit

### DIFF
--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -34,7 +34,7 @@ The URI for the `Integer` data type is `xsd:nonNegativeInteger`.
 
 An enumeration is a selection from a set of options.
 They are represented as a string matching the same production as a tag,
-with the additional permission that standard enumerations may begin with a digit.
+with the additional permission that standard enumerations may be integers.
 
 ```abnf
 stdEnum = stdTag / digit *tagchar

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -37,7 +37,7 @@ They are represented as a string matching the same production as a tag,
 with the additional permission that standard enumerations may be integers.
 
 ```abnf
-stdEnum = stdTag / digit *tagchar
+stdEnum = stdTag / Integer
 Enum    = stdEnum / extTag
 ```
 

--- a/specification/gedcom-02-datatypes.md
+++ b/specification/gedcom-02-datatypes.md
@@ -33,14 +33,16 @@ The URI for the `Integer` data type is `xsd:nonNegativeInteger`.
 ## Enumeration
 
 An enumeration is a selection from a set of options.
-They are represented as a string matching the same production as a tag.
+They are represented as a string matching the same production as a tag,
+with the additional permission that standard enumerations may begin with a digit.
 
 ```abnf
-Enum    = Tag
+stdEnum = stdTag / digit *tagchar
+Enum    = stdEnum / extTag
 ```
 
 Each structure type with an enumeration payload also defines specific payload values it permits.
-These permitted payloads match production `stdTag` and should each have a defined URI.
+These permitted payloads match production `stdEnum` and should each have a defined URI.
 Payload values that match production `extTag` are always permitted in structures with an enumeration payload
 and have their URI defined by the schema.
 


### PR DESCRIPTION
As noted in #229, `QUAY` uses digit-beginning enumeration values so the spec should document that they are allowed.

This is the most permissive of the fixes discussed in #229; more restrictive changes like

> with the additional permission that standard enumerations may be single digits.
>
> ```abnf
> stdEnum = stdTag / digit
> ```

or 

> with the additional permission that standard enumerations may be non-negative integers.
>
> ```abnf
> stdEnum = stdTag / Integer
> ```

 might be better to minimize disruption.