### PR TITLE
EXID.TYPE for FindAGrave.com identifiers

### DIFF
--- a/exid-types.json
+++ b/exid-types.json
@@ -64,5 +64,21 @@
     "contact": "GEDCOM@familysearch.org",
     "change-controller": "FamilySearch",
     "reference": "https://gedcom.io/exid-type/FamilySearch-UserId"
+  },
+  {
+    "label": "FindAGrave Memorial ID",
+    "type": "https://www.findagrave.com/memorial",
+    "description": "FindAGrave Memorial ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FindAGrave.com",
+    "reference": "https://support.findagrave.com/s/article/Memorial-Search"
+  },
+  {
+    "label": "FindAGrave Cemetery ID",
+    "type": "https://www.findagrave.com/cemetery",
+    "description": "FindAGrave Cemetery ID",
+    "contact": "GEDCOM@familysearch.org",
+    "change-controller": "FindAGrave.com",
+    "reference": "https://support.findagrave.com/s/article/Cemetery-Search"
   }
 ]


### PR DESCRIPTION
Ideally the change controller would be someone from Find a Grave. However, this PR is testing a third-party registration process.

Fixes #261

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>