### PR TITLE
Add URIs for all pseudostructures

### DIFF
--- a/build/uri-def.py
+++ b/build/uri-def.py
@@ -162,7 +162,7 @@ def new_key(val, d, *keys, msg=''):
 
 def parse_gedstruct(txt, rules, dtypes):
     """Reads through all gedstruct blocks to find payloads, substructures, and superstructures"""
-    sup,sub,payload = {}, {}, {}
+    sup,sub,payload = {'g7:CONT':[],'g7:CONC':[]}, {}, {}
     for block in re.findall(r'```[^\n]*gedstruct[^\n]*\n([^`]*)\n```', txt):
         stack = []
         for line in block.split('\n'):
@@ -184,8 +184,6 @@ def parse_gedstruct(txt, rules, dtypes):
                         new_key(joint_card(card,c), sub, stack[-1], u, msg='rule sub: ')
             else:
                 uri = parts[-1]
-                if '{' in uri:
-                    uri = parts[1]+' pseudostructure'
                 card = parts[-2]
                 if len(parts) > 4:
                     p = ' '.join(parts[2:-2])[1:-1]
@@ -226,7 +224,6 @@ def find_descriptions(txt, g7, ssp):
     
     # error check that gedstruct and sections align
     for uri in ssp:
-        if 'pseudostructure' in uri: continue
         if uri.startswith('g7:') and uri[3:] not in g7:
             raise Exception('Found gedstruct for '+uri+' but no section')
 

--- a/extracted-files/cardinalities.tsv
+++ b/extracted-files/cardinalities.tsv
@@ -281,7 +281,7 @@ https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/CHR	{0:M}
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/CITY	{0:1}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/CONF	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/CONL	{0:M}
-HEAD pseudostructure	https://gedcom.io/terms/v7/COPR	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/COPR	{0:1}
 https://gedcom.io/terms/v7/HEAD-SOUR-DATA	https://gedcom.io/terms/v7/COPR	{0:1}
 https://gedcom.io/terms/v7/HEAD-SOUR	https://gedcom.io/terms/v7/CORP	{0:1}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/CREA	{0:1}
@@ -359,12 +359,12 @@ https://gedcom.io/terms/v7/CHAN	https://gedcom.io/terms/v7/DATE-exact	{1:1}
 https://gedcom.io/terms/v7/CREA	https://gedcom.io/terms/v7/DATE-exact	{1:1}
 https://gedcom.io/terms/v7/HEAD-SOUR-DATA	https://gedcom.io/terms/v7/DATE-exact	{0:1}
 https://gedcom.io/terms/v7/ord-STAT	https://gedcom.io/terms/v7/DATE-exact	{1:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/HEAD-DATE	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/HEAD-DATE	{0:1}
 https://gedcom.io/terms/v7/NO	https://gedcom.io/terms/v7/NO-DATE	{0:1}
 https://gedcom.io/terms/v7/DATA-EVEN	https://gedcom.io/terms/v7/DATA-EVEN-DATE	{0:1}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/DEAT	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/DESI	{0:M}
-HEAD pseudostructure	https://gedcom.io/terms/v7/DEST	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/DEST	{0:1}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/DIVF	{0:M}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/DIV	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/DSCR	{0:M}
@@ -506,7 +506,7 @@ https://gedcom.io/terms/v7/FILE	https://gedcom.io/terms/v7/FORM	{1:1}
 https://gedcom.io/terms/v7/FILE-TRAN	https://gedcom.io/terms/v7/FORM	{1:1}
 https://gedcom.io/terms/v7/PLAC	https://gedcom.io/terms/v7/PLAC-FORM	{0:1}
 https://gedcom.io/terms/v7/HEAD-PLAC	https://gedcom.io/terms/v7/HEAD-PLAC-FORM	{1:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/GEDC	{1:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/GEDC	{1:1}
 https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/GIVN	{0:M}
 https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/GIVN	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/GRAD	{0:M}
@@ -536,7 +536,7 @@ https://gedcom.io/terms/v7/PLAC	https://gedcom.io/terms/v7/LANG	{0:1}
 https://gedcom.io/terms/v7/PLAC-TRAN	https://gedcom.io/terms/v7/LANG	{1:1}
 https://gedcom.io/terms/v7/TEXT	https://gedcom.io/terms/v7/LANG	{0:1}
 https://gedcom.io/terms/v7/record-SNOTE	https://gedcom.io/terms/v7/LANG	{0:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/HEAD-LANG	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/HEAD-LANG	{0:1}
 https://gedcom.io/terms/v7/record-SUBM	https://gedcom.io/terms/v7/SUBM-LANG	{0:M}
 https://gedcom.io/terms/v7/MAP	https://gedcom.io/terms/v7/LATI	{1:1}
 https://gedcom.io/terms/v7/CROP	https://gedcom.io/terms/v7/LEFT	{0:1}
@@ -566,7 +566,6 @@ https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/NICK	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NMR	{0:M}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/NO	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/NO	{0:M}
-HEAD pseudostructure	https://gedcom.io/terms/v7/NOTE	{0:1}
 https://gedcom.io/terms/v7/ADOP	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/ANUL	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/ASSO	https://gedcom.io/terms/v7/NOTE	{0:M}
@@ -601,6 +600,7 @@ https://gedcom.io/terms/v7/FAM-RESI	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/FAMS	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/FCOM	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/GRAD	https://gedcom.io/terms/v7/NOTE	{0:M}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/NOTE	{0:1}
 https://gedcom.io/terms/v7/IDNO	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/IMMI	https://gedcom.io/terms/v7/NOTE	{0:M}
 https://gedcom.io/terms/v7/INDI-CENS	https://gedcom.io/terms/v7/NOTE	{0:M}
@@ -833,7 +833,7 @@ https://gedcom.io/terms/v7/SLGC	https://gedcom.io/terms/v7/PLAC	{0:1}
 https://gedcom.io/terms/v7/SLGS	https://gedcom.io/terms/v7/PLAC	{0:1}
 https://gedcom.io/terms/v7/SSN	https://gedcom.io/terms/v7/PLAC	{0:1}
 https://gedcom.io/terms/v7/WILL	https://gedcom.io/terms/v7/PLAC	{0:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/HEAD-PLAC	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/HEAD-PLAC	{0:1}
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/POST	{0:1}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/PROB	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/PROP	{0:M}
@@ -958,7 +958,7 @@ https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/INDI-RESI	{0:M
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/RETI	{0:M}
 https://gedcom.io/terms/v7/ASSO	https://gedcom.io/terms/v7/ROLE	{1:1}
 https://gedcom.io/terms/v7/SOUR-EVEN	https://gedcom.io/terms/v7/ROLE	{0:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/SCHMA	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/SCHMA	{0:1}
 https://gedcom.io/terms/v7/ADOP	https://gedcom.io/terms/v7/SDATE	{0:1}
 https://gedcom.io/terms/v7/ANUL	https://gedcom.io/terms/v7/SDATE	{0:1}
 https://gedcom.io/terms/v7/BAPM	https://gedcom.io/terms/v7/SDATE	{0:1}
@@ -1013,7 +1013,6 @@ https://gedcom.io/terms/v7/WILL	https://gedcom.io/terms/v7/SDATE	{0:1}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SEX	{0:1}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SLGC	{0:M}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/SLGS	{0:M}
-HEAD pseudostructure	https://gedcom.io/terms/v7/SNOTE	{0:1}
 https://gedcom.io/terms/v7/ADOP	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/ANUL	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/ASSO	https://gedcom.io/terms/v7/SNOTE	{0:M}
@@ -1048,6 +1047,7 @@ https://gedcom.io/terms/v7/FAM-RESI	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/FAMS	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/FCOM	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/GRAD	https://gedcom.io/terms/v7/SNOTE	{0:M}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/SNOTE	{0:1}
 https://gedcom.io/terms/v7/IDNO	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/IMMI	https://gedcom.io/terms/v7/SNOTE	{0:M}
 https://gedcom.io/terms/v7/INDI-CENS	https://gedcom.io/terms/v7/SNOTE	{0:M}
@@ -1152,7 +1152,7 @@ https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/SOUR	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SOUR	{0:M}
 https://gedcom.io/terms/v7/record-OBJE	https://gedcom.io/terms/v7/SOUR	{0:M}
 https://gedcom.io/terms/v7/record-SNOTE	https://gedcom.io/terms/v7/SOUR	{0:M}
-HEAD pseudostructure	https://gedcom.io/terms/v7/HEAD-SOUR	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/HEAD-SOUR	{0:1}
 https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SPFX	{0:M}
 https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/SPFX	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SSN	{0:M}
@@ -1164,7 +1164,7 @@ https://gedcom.io/terms/v7/INIL	https://gedcom.io/terms/v7/ord-STAT	{0:1}
 https://gedcom.io/terms/v7/SLGC	https://gedcom.io/terms/v7/ord-STAT	{0:1}
 https://gedcom.io/terms/v7/SLGS	https://gedcom.io/terms/v7/ord-STAT	{0:1}
 https://gedcom.io/terms/v7/INDI-FAMC	https://gedcom.io/terms/v7/FAMC-STAT	{0:1}
-HEAD pseudostructure	https://gedcom.io/terms/v7/SUBM	{0:1}
+https://gedcom.io/terms/v7/HEAD	https://gedcom.io/terms/v7/SUBM	{0:1}
 https://gedcom.io/terms/v7/record-FAM	https://gedcom.io/terms/v7/SUBM	{0:M}
 https://gedcom.io/terms/v7/record-INDI	https://gedcom.io/terms/v7/SUBM	{0:M}
 https://gedcom.io/terms/v7/INDI-NAME	https://gedcom.io/terms/v7/SURN	{0:M}

--- a/extracted-files/grammar.gedstruct
+++ b/extracted-files/grammar.gedstruct
@@ -1,7 +1,7 @@
 Dataset :=
 0 <<HEADER>>                               {1:1}
 0 <<RECORD>>                               {0:M}
-0 TRLR                                     {1:1} 
+0 TRLR                                     {1:1}  g7:TRLR
 
 
 RECORD :=
@@ -23,7 +23,7 @@ n <<SUBMITTER_RECORD>>                     {1:1}
 
 
 HEADER :=
-n HEAD                                     {1:1} 
+n HEAD                                     {1:1}  g7:HEAD
   +1 GEDC                                  {1:1}  g7:GEDC
      +2 VERS <Special>                     {1:1}  g7:GEDC-VERS
   +1 SCHMA                                 {0:1}  g7:SCHMA

--- a/extracted-files/payloads.tsv
+++ b/extracted-files/payloads.tsv
@@ -29,8 +29,10 @@ https://gedcom.io/terms/v7/CHIL	@<https://gedcom.io/terms/v7/record-INDI>@
 https://gedcom.io/terms/v7/CHRA	Y|<NULL>
 https://gedcom.io/terms/v7/CHR	Y|<NULL>
 https://gedcom.io/terms/v7/CITY	http://www.w3.org/2001/XMLSchema#string
+https://gedcom.io/terms/v7/CONC	
 https://gedcom.io/terms/v7/CONF	Y|<NULL>
 https://gedcom.io/terms/v7/CONL	
+https://gedcom.io/terms/v7/CONT	
 https://gedcom.io/terms/v7/COPR	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/CORP	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/CREA	
@@ -77,6 +79,7 @@ https://gedcom.io/terms/v7/HEAD-PLAC-FORM	https://gedcom.io/terms/v7/type-List#T
 https://gedcom.io/terms/v7/GEDC	
 https://gedcom.io/terms/v7/GIVN	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/GRAD	Y|<NULL>
+https://gedcom.io/terms/v7/HEAD	
 https://gedcom.io/terms/v7/HEIGHT	http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 https://gedcom.io/terms/v7/HUSB	
 https://gedcom.io/terms/v7/FAM-HUSB	@<https://gedcom.io/terms/v7/record-INDI>@
@@ -164,6 +167,7 @@ https://gedcom.io/terms/v7/NAME-TRAN	https://gedcom.io/terms/v7/type-Name
 https://gedcom.io/terms/v7/PLAC-TRAN	https://gedcom.io/terms/v7/type-List#Text
 https://gedcom.io/terms/v7/NOTE-TRAN	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/FILE-TRAN	http://www.w3.org/2001/XMLSchema#string
+https://gedcom.io/terms/v7/TRLR	
 https://gedcom.io/terms/v7/TYPE	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/NAME-TYPE	https://gedcom.io/terms/v7/type-Enum
 https://gedcom.io/terms/v7/EXID-TYPE	http://www.w3.org/2001/XMLSchema#string

--- a/extracted-files/substructures.tsv
+++ b/extracted-files/substructures.tsv
@@ -279,9 +279,11 @@ https://gedcom.io/terms/v7/record-FAM	CHIL	https://gedcom.io/terms/v7/CHIL
 https://gedcom.io/terms/v7/record-INDI	CHRA	https://gedcom.io/terms/v7/CHRA
 https://gedcom.io/terms/v7/record-INDI	CHR	https://gedcom.io/terms/v7/CHR
 https://gedcom.io/terms/v7/ADDR	CITY	https://gedcom.io/terms/v7/CITY
+	CONC	https://gedcom.io/terms/v7/CONC
 https://gedcom.io/terms/v7/record-INDI	CONF	https://gedcom.io/terms/v7/CONF
 https://gedcom.io/terms/v7/record-INDI	CONL	https://gedcom.io/terms/v7/CONL
-HEAD pseudostructure	COPR	https://gedcom.io/terms/v7/COPR
+	CONT	https://gedcom.io/terms/v7/CONT
+https://gedcom.io/terms/v7/HEAD	COPR	https://gedcom.io/terms/v7/COPR
 https://gedcom.io/terms/v7/HEAD-SOUR-DATA	COPR	https://gedcom.io/terms/v7/COPR
 https://gedcom.io/terms/v7/HEAD-SOUR	CORP	https://gedcom.io/terms/v7/CORP
 https://gedcom.io/terms/v7/record-FAM	CREA	https://gedcom.io/terms/v7/CREA
@@ -359,12 +361,12 @@ https://gedcom.io/terms/v7/CHAN	DATE	https://gedcom.io/terms/v7/DATE-exact
 https://gedcom.io/terms/v7/CREA	DATE	https://gedcom.io/terms/v7/DATE-exact
 https://gedcom.io/terms/v7/HEAD-SOUR-DATA	DATE	https://gedcom.io/terms/v7/DATE-exact
 https://gedcom.io/terms/v7/ord-STAT	DATE	https://gedcom.io/terms/v7/DATE-exact
-HEAD pseudostructure	DATE	https://gedcom.io/terms/v7/HEAD-DATE
+https://gedcom.io/terms/v7/HEAD	DATE	https://gedcom.io/terms/v7/HEAD-DATE
 https://gedcom.io/terms/v7/NO	DATE	https://gedcom.io/terms/v7/NO-DATE
 https://gedcom.io/terms/v7/DATA-EVEN	DATE	https://gedcom.io/terms/v7/DATA-EVEN-DATE
 https://gedcom.io/terms/v7/record-INDI	DEAT	https://gedcom.io/terms/v7/DEAT
 https://gedcom.io/terms/v7/record-INDI	DESI	https://gedcom.io/terms/v7/DESI
-HEAD pseudostructure	DEST	https://gedcom.io/terms/v7/DEST
+https://gedcom.io/terms/v7/HEAD	DEST	https://gedcom.io/terms/v7/DEST
 https://gedcom.io/terms/v7/record-FAM	DIVF	https://gedcom.io/terms/v7/DIVF
 https://gedcom.io/terms/v7/record-FAM	DIV	https://gedcom.io/terms/v7/DIV
 https://gedcom.io/terms/v7/record-INDI	DSCR	https://gedcom.io/terms/v7/DSCR
@@ -507,10 +509,11 @@ https://gedcom.io/terms/v7/FILE	FORM	https://gedcom.io/terms/v7/FORM
 https://gedcom.io/terms/v7/FILE-TRAN	FORM	https://gedcom.io/terms/v7/FORM
 https://gedcom.io/terms/v7/PLAC	FORM	https://gedcom.io/terms/v7/PLAC-FORM
 https://gedcom.io/terms/v7/HEAD-PLAC	FORM	https://gedcom.io/terms/v7/HEAD-PLAC-FORM
-HEAD pseudostructure	GEDC	https://gedcom.io/terms/v7/GEDC
+https://gedcom.io/terms/v7/HEAD	GEDC	https://gedcom.io/terms/v7/GEDC
 https://gedcom.io/terms/v7/INDI-NAME	GIVN	https://gedcom.io/terms/v7/GIVN
 https://gedcom.io/terms/v7/NAME-TRAN	GIVN	https://gedcom.io/terms/v7/GIVN
 https://gedcom.io/terms/v7/record-INDI	GRAD	https://gedcom.io/terms/v7/GRAD
+	HEAD	https://gedcom.io/terms/v7/HEAD
 https://gedcom.io/terms/v7/CROP	HEIGHT	https://gedcom.io/terms/v7/HEIGHT
 https://gedcom.io/terms/v7/ANUL	HUSB	https://gedcom.io/terms/v7/HUSB
 https://gedcom.io/terms/v7/DIV	HUSB	https://gedcom.io/terms/v7/HUSB
@@ -538,7 +541,7 @@ https://gedcom.io/terms/v7/PLAC	LANG	https://gedcom.io/terms/v7/LANG
 https://gedcom.io/terms/v7/PLAC-TRAN	LANG	https://gedcom.io/terms/v7/LANG
 https://gedcom.io/terms/v7/TEXT	LANG	https://gedcom.io/terms/v7/LANG
 https://gedcom.io/terms/v7/record-SNOTE	LANG	https://gedcom.io/terms/v7/LANG
-HEAD pseudostructure	LANG	https://gedcom.io/terms/v7/HEAD-LANG
+https://gedcom.io/terms/v7/HEAD	LANG	https://gedcom.io/terms/v7/HEAD-LANG
 https://gedcom.io/terms/v7/record-SUBM	LANG	https://gedcom.io/terms/v7/SUBM-LANG
 https://gedcom.io/terms/v7/MAP	LATI	https://gedcom.io/terms/v7/LATI
 https://gedcom.io/terms/v7/CROP	LEFT	https://gedcom.io/terms/v7/LEFT
@@ -568,7 +571,6 @@ https://gedcom.io/terms/v7/NAME-TRAN	NICK	https://gedcom.io/terms/v7/NICK
 https://gedcom.io/terms/v7/record-INDI	NMR	https://gedcom.io/terms/v7/NMR
 https://gedcom.io/terms/v7/record-FAM	NO	https://gedcom.io/terms/v7/NO
 https://gedcom.io/terms/v7/record-INDI	NO	https://gedcom.io/terms/v7/NO
-HEAD pseudostructure	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/ADOP	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/ANUL	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/ASSO	NOTE	https://gedcom.io/terms/v7/NOTE
@@ -603,6 +605,7 @@ https://gedcom.io/terms/v7/FAM-RESI	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/FAMS	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/FCOM	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/GRAD	NOTE	https://gedcom.io/terms/v7/NOTE
+https://gedcom.io/terms/v7/HEAD	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/IDNO	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/IMMI	NOTE	https://gedcom.io/terms/v7/NOTE
 https://gedcom.io/terms/v7/INDI-CENS	NOTE	https://gedcom.io/terms/v7/NOTE
@@ -836,7 +839,7 @@ https://gedcom.io/terms/v7/SLGC	PLAC	https://gedcom.io/terms/v7/PLAC
 https://gedcom.io/terms/v7/SLGS	PLAC	https://gedcom.io/terms/v7/PLAC
 https://gedcom.io/terms/v7/SSN	PLAC	https://gedcom.io/terms/v7/PLAC
 https://gedcom.io/terms/v7/WILL	PLAC	https://gedcom.io/terms/v7/PLAC
-HEAD pseudostructure	PLAC	https://gedcom.io/terms/v7/HEAD-PLAC
+https://gedcom.io/terms/v7/HEAD	PLAC	https://gedcom.io/terms/v7/HEAD-PLAC
 https://gedcom.io/terms/v7/ADDR	POST	https://gedcom.io/terms/v7/POST
 https://gedcom.io/terms/v7/record-INDI	PROB	https://gedcom.io/terms/v7/PROB
 https://gedcom.io/terms/v7/record-INDI	PROP	https://gedcom.io/terms/v7/PROP
@@ -962,7 +965,7 @@ https://gedcom.io/terms/v7/record-INDI	RESI	https://gedcom.io/terms/v7/INDI-RESI
 https://gedcom.io/terms/v7/record-INDI	RETI	https://gedcom.io/terms/v7/RETI
 https://gedcom.io/terms/v7/ASSO	ROLE	https://gedcom.io/terms/v7/ROLE
 https://gedcom.io/terms/v7/SOUR-EVEN	ROLE	https://gedcom.io/terms/v7/ROLE
-HEAD pseudostructure	SCHMA	https://gedcom.io/terms/v7/SCHMA
+https://gedcom.io/terms/v7/HEAD	SCHMA	https://gedcom.io/terms/v7/SCHMA
 https://gedcom.io/terms/v7/ADOP	SDATE	https://gedcom.io/terms/v7/SDATE
 https://gedcom.io/terms/v7/ANUL	SDATE	https://gedcom.io/terms/v7/SDATE
 https://gedcom.io/terms/v7/BAPM	SDATE	https://gedcom.io/terms/v7/SDATE
@@ -1017,7 +1020,6 @@ https://gedcom.io/terms/v7/WILL	SDATE	https://gedcom.io/terms/v7/SDATE
 https://gedcom.io/terms/v7/record-INDI	SEX	https://gedcom.io/terms/v7/SEX
 https://gedcom.io/terms/v7/record-INDI	SLGC	https://gedcom.io/terms/v7/SLGC
 https://gedcom.io/terms/v7/record-FAM	SLGS	https://gedcom.io/terms/v7/SLGS
-HEAD pseudostructure	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/ADOP	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/ANUL	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/ASSO	SNOTE	https://gedcom.io/terms/v7/SNOTE
@@ -1052,6 +1054,7 @@ https://gedcom.io/terms/v7/FAM-RESI	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/FAMS	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/FCOM	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/GRAD	SNOTE	https://gedcom.io/terms/v7/SNOTE
+https://gedcom.io/terms/v7/HEAD	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/IDNO	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/IMMI	SNOTE	https://gedcom.io/terms/v7/SNOTE
 https://gedcom.io/terms/v7/INDI-CENS	SNOTE	https://gedcom.io/terms/v7/SNOTE
@@ -1158,7 +1161,7 @@ https://gedcom.io/terms/v7/record-INDI	SOUR	https://gedcom.io/terms/v7/SOUR
 https://gedcom.io/terms/v7/record-OBJE	SOUR	https://gedcom.io/terms/v7/SOUR
 https://gedcom.io/terms/v7/record-SNOTE	SOUR	https://gedcom.io/terms/v7/SOUR
 	SOUR	https://gedcom.io/terms/v7/record-SOUR
-HEAD pseudostructure	SOUR	https://gedcom.io/terms/v7/HEAD-SOUR
+https://gedcom.io/terms/v7/HEAD	SOUR	https://gedcom.io/terms/v7/HEAD-SOUR
 https://gedcom.io/terms/v7/INDI-NAME	SPFX	https://gedcom.io/terms/v7/SPFX
 https://gedcom.io/terms/v7/NAME-TRAN	SPFX	https://gedcom.io/terms/v7/SPFX
 https://gedcom.io/terms/v7/record-INDI	SSN	https://gedcom.io/terms/v7/SSN
@@ -1170,7 +1173,7 @@ https://gedcom.io/terms/v7/INIL	STAT	https://gedcom.io/terms/v7/ord-STAT
 https://gedcom.io/terms/v7/SLGC	STAT	https://gedcom.io/terms/v7/ord-STAT
 https://gedcom.io/terms/v7/SLGS	STAT	https://gedcom.io/terms/v7/ord-STAT
 https://gedcom.io/terms/v7/INDI-FAMC	STAT	https://gedcom.io/terms/v7/FAMC-STAT
-HEAD pseudostructure	SUBM	https://gedcom.io/terms/v7/SUBM
+https://gedcom.io/terms/v7/HEAD	SUBM	https://gedcom.io/terms/v7/SUBM
 https://gedcom.io/terms/v7/record-FAM	SUBM	https://gedcom.io/terms/v7/SUBM
 https://gedcom.io/terms/v7/record-INDI	SUBM	https://gedcom.io/terms/v7/SUBM
 	SUBM	https://gedcom.io/terms/v7/record-SUBM
@@ -1199,6 +1202,7 @@ https://gedcom.io/terms/v7/PLAC	TRAN	https://gedcom.io/terms/v7/PLAC-TRAN
 https://gedcom.io/terms/v7/NOTE	TRAN	https://gedcom.io/terms/v7/NOTE-TRAN
 https://gedcom.io/terms/v7/record-SNOTE	TRAN	https://gedcom.io/terms/v7/NOTE-TRAN
 https://gedcom.io/terms/v7/FILE	TRAN	https://gedcom.io/terms/v7/FILE-TRAN
+	TRLR	https://gedcom.io/terms/v7/TRLR
 https://gedcom.io/terms/v7/ADOP	TYPE	https://gedcom.io/terms/v7/TYPE
 https://gedcom.io/terms/v7/ANUL	TYPE	https://gedcom.io/terms/v7/TYPE
 https://gedcom.io/terms/v7/BAPM	TYPE	https://gedcom.io/terms/v7/TYPE

--- a/extracted-files/tags/COPR
+++ b/extracted-files/tags/COPR
@@ -18,6 +18,6 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: {}
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/HEAD-SOUR-DATA": "{0:1}"
 ...

--- a/extracted-files/tags/DEST
+++ b/extracted-files/tags/DEST
@@ -18,5 +18,5 @@ payload: http://www.w3.org/2001/XMLSchema#string
 substructures: {}
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/GEDC
+++ b/extracted-files/tags/GEDC
@@ -22,5 +22,5 @@ substructures:
   "https://gedcom.io/terms/v7/GEDC-VERS": "{1:1}"
 
 superstructures:
-  "HEAD pseudostructure": "{1:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{1:1}"
 ...

--- a/extracted-files/tags/HEAD-DATE
+++ b/extracted-files/tags/HEAD-DATE
@@ -18,5 +18,5 @@ substructures:
   "https://gedcom.io/terms/v7/TIME": "{0:1}"
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/HEAD-LANG
+++ b/extracted-files/tags/HEAD-LANG
@@ -36,5 +36,5 @@ payload: http://www.w3.org/2001/XMLSchema#Language
 substructures: {}
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/HEAD-PLAC
+++ b/extracted-files/tags/HEAD-PLAC
@@ -19,5 +19,5 @@ substructures:
   "https://gedcom.io/terms/v7/HEAD-PLAC-FORM": "{1:1}"
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/HEAD-SOUR
+++ b/extracted-files/tags/HEAD-SOUR
@@ -24,5 +24,5 @@ substructures:
   "https://gedcom.io/terms/v7/VERS": "{0:1}"
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/NOTE
+++ b/extracted-files/tags/NOTE
@@ -28,7 +28,6 @@ substructures:
   "https://gedcom.io/terms/v7/SOUR": "{0:M}"
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
   "https://gedcom.io/terms/v7/ADOP": "{0:M}"
   "https://gedcom.io/terms/v7/ANUL": "{0:M}"
   "https://gedcom.io/terms/v7/ASSO": "{0:M}"
@@ -63,6 +62,7 @@ superstructures:
   "https://gedcom.io/terms/v7/FAMS": "{0:M}"
   "https://gedcom.io/terms/v7/FCOM": "{0:M}"
   "https://gedcom.io/terms/v7/GRAD": "{0:M}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/IDNO": "{0:M}"
   "https://gedcom.io/terms/v7/IMMI": "{0:M}"
   "https://gedcom.io/terms/v7/INDI-CENS": "{0:M}"

--- a/extracted-files/tags/SCHMA
+++ b/extracted-files/tags/SCHMA
@@ -19,5 +19,5 @@ substructures:
   "https://gedcom.io/terms/v7/TAG": "{0:M}"
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
 ...

--- a/extracted-files/tags/SNOTE
+++ b/extracted-files/tags/SNOTE
@@ -18,7 +18,6 @@ payload: "@<https://gedcom.io/terms/v7/record-SNOTE>@"
 substructures: {}
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
   "https://gedcom.io/terms/v7/ADOP": "{0:M}"
   "https://gedcom.io/terms/v7/ANUL": "{0:M}"
   "https://gedcom.io/terms/v7/ASSO": "{0:M}"
@@ -53,6 +52,7 @@ superstructures:
   "https://gedcom.io/terms/v7/FAMS": "{0:M}"
   "https://gedcom.io/terms/v7/FCOM": "{0:M}"
   "https://gedcom.io/terms/v7/GRAD": "{0:M}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/IDNO": "{0:M}"
   "https://gedcom.io/terms/v7/IMMI": "{0:M}"
   "https://gedcom.io/terms/v7/INDI-CENS": "{0:M}"

--- a/extracted-files/tags/SUBM
+++ b/extracted-files/tags/SUBM
@@ -18,7 +18,7 @@ payload: "@<https://gedcom.io/terms/v7/record-SUBM>@"
 substructures: {}
 
 superstructures:
-  "HEAD pseudostructure": "{0:1}"
+  "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
 ...

--- a/specification/gedcom-03-datamodel.md
+++ b/specification/gedcom-03-datamodel.md
@@ -99,7 +99,7 @@ and a superstructure with tag `GEDC`.
 ```gedstruct
 0 <<HEADER>>                               {1:1}
 0 <<RECORD>>                               {0:M}
-0 TRLR                                     {1:1} 
+0 TRLR                                     {1:1}  g7:TRLR
 ```
 
 The order of these is significant:
@@ -129,7 +129,7 @@ n <<SUBMITTER_RECORD>>                     {1:1}
 #### `HEADER` :=
 
 ```gedstruct
-n HEAD                                     {1:1} 
+n HEAD                                     {1:1}  g7:HEAD
   +1 GEDC                                  {1:1}  g7:GEDC
      +2 VERS <Special>                     {1:1}  g7:GEDC-VERS
   +1 SCHMA                                 {0:1}  g7:SCHMA
@@ -1538,6 +1538,12 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 The name of the city used in the address.
 See `ADDRESS_STRUCTURE` for more.
 
+#### `CONC` (Concatenated) `g7:CONC`
+
+A pseudo-structure using in versions prior to 7.0 to split payloads across multiple lines.
+`CONC` does not appear in version 7 datasets, either in serialized or parsed form.
+Because of its significance in pre-7 versions, the `CONC` tag is reserved and well never be re-used to identify a structure type.
+
 #### `CONF` (Confirmation)  `g7:CONF`
 
 An [Individual Event](#individual-events).
@@ -1548,9 +1554,10 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
-#### `CONT` (Continued)
+#### `CONT` (Continued) `g7:CONT`
 
 A pseudo-structure to indicate a line break.
+The `CONT` tag is generated during serialization and is never present in parsed datasets.
 See [Lines](#lines) for more.
 
 #### `COPR` (Copyright) `g7:COPR`
@@ -1889,7 +1896,7 @@ A given or earned name used for official identification of a person.
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `HEAD` (Header)
+#### `HEAD` (Header) `g7:HEAD`
 
 A pseudo-structure for storing metadata about the document.
 See [The Header and Trailer](#the-header) for more.
@@ -2710,7 +2717,7 @@ Files that differ in the human language of their content
 should each be given their own `FILE` structure.
 
 
-#### `TRLR` (Trailer)
+#### `TRLR` (Trailer) `g7:TRLR`
 
 A pseudo-structure marking the end of a dataset.
 See [The Header and Trailer](#the-header) for more.


### PR DESCRIPTION
- `HEAD` as `g7:HEAD`, replacing "HEAD pseudostructure" in extracted files
- `TRLR` as `g7:TRLR`
- `CONT` as `g7:CONT`; also add that it is removed during parsing and never appears in parses datasets
- `CONC` as `g7:CONC`; also document that this had meaning in pre-7 versions and will not appear in 7.0 nor be re-used for a different stucture in the future