### PR TITLE
Structure for proposing new events

### DIFF
--- a/attribute-event-requests/FAM-attribute.md
+++ b/attribute-event-requests/FAM-attribute.md
@@ -1,17 +1,28 @@
-# Proposed Family Attributes
+# Family Attributes
 
-This document tracks various proposed additions to the set of Family Attributes in FamilySearch GEDCOM 7.
+This document tracks the set of Family Attributes, both those in FamilySearch GEDCOM 7 and those considered for future addition.
 Guides for using this document can be found in the associated [README.md](README.md).
 
+# Table
 
-# Table of Proposals
+| G7 Tag | Since | Name | Notes |
+|:------:|-------|------|-------|
+| `NCHI` | 5.0 | Number of children | |
+| `RESI` | 3.0 | Residence | |
+| \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
+| | | [Lived Together](#lived-together) | perhaps `RESI`? |
 
-| G7 Tag | v7.x| Name           | URIs | Notes |
-|:------:|-----|----------------|------|-------|
-| \*     | 7.0 | Childless | `http://familysearch.org/v1/CoupleNeverHadChildren` | in 7.0 as `NCH 0` |
-|        |     | [Lived Together](#lived-together) | `http://familysearch.org/v1/LivedTogether` | perhaps `RESI`? |
+# Details
 
-# Details of Proposals
+## Childless
+
+The assertion that a family does not have children can be made using the `NCHI` structure with payload "`0`".
+This is distinct from simply not having any `CHIL` structures,
+which might mean there are children that have not yet been added to the data.
+
+### Used
+
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as a distinct stucture with URI `http://familysearch.org/v1/CoupleNeverHadChildren`
 
 ## Lived together
 
@@ -41,4 +52,4 @@ Related proposals include
 
 ### Used
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/LivedTogether`

--- a/attribute-event-requests/FAM-attribute.md
+++ b/attribute-event-requests/FAM-attribute.md
@@ -7,10 +7,10 @@ Guides for using this document can be found in the associated [README.md](README
 
 | G7 Tag | Since | Name | Notes |
 |:------:|-------|------|-------|
-| `NCHI` | 5.0 | Number of children | |
-| `RESI` | 3.0 | Residence | |
 | \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
 | | | [Lived Together](#lived-together) | perhaps `RESI`? |
+| `NCHI` | 5.0 | Number of children | |
+| `RESI` | 3.0 | Residence | |
 
 # Details
 

--- a/attribute-event-requests/FAM-attribute.md
+++ b/attribute-event-requests/FAM-attribute.md
@@ -1,0 +1,44 @@
+# Proposed Family Attributes
+
+This document tracks various proposed additions to the set of Family Attributes in FamilySearch GEDCOM 7.
+Guides for using this document can be found in the associated [README.md](README.md).
+
+
+# Table of Proposals
+
+| G7 Tag | v7.x| Name           | URIs | Notes |
+|:------:|-----|----------------|------|-------|
+| \*     | 7.0 | Childless | `http://familysearch.org/v1/CoupleNeverHadChildren` | in 7.0 as `NCH 0` |
+|        |     | [Lived Together](#lived-together) | `http://familysearch.org/v1/LivedTogether` | perhaps `RESI`? |
+
+# Details of Proposals
+
+## Lived together
+
+### Description
+
+*proposed description missing*
+
+*In [FamilySearch API documentation](https://www.familysearch.org/developers/docs/guides/facts)* without a definition
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- `FAM`.`RESI`: provides the place of residence for the couple, which generally implies they lived together. However, "lived together" is sometimes used as a euphemism for "acted as a couple without a preceding marriage ceremony," which is only indirectly implied by the presence of a `FAM`.`RESI`.
+- `MARR`: some interpretations of living together as a couple and some definitions of marriage make living together a type of marriage; other definitions do not.
+
+Related proposals include
+
+- Common Law Marriage (in the Family Events document): some interpretations of common law marriage and cohabitation are very similar to one another
+
+
+### Used
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>

--- a/attribute-event-requests/FAM-attribute.md
+++ b/attribute-event-requests/FAM-attribute.md
@@ -7,7 +7,7 @@ Guides for using this document can be found in the associated [README.md](README
 
 | G7 Tag | Since | Name | Notes |
 |:------:|-------|------|-------|
-| \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
+| \*     | 5.0 | [Childless](#childless) | encoded as `NCHI 0` |
 | | | [Lived Together](#lived-together) | perhaps `RESI`? |
 | `NCHI` | 5.0 | Number of children | |
 | `RESI` | 3.0 | Residence | |

--- a/attribute-event-requests/FAM-event.md
+++ b/attribute-event-requests/FAM-event.md
@@ -1,20 +1,28 @@
-# Proposed Family Events
+# Family Events
 
-This document tracks various proposed additions to the set of Family Events in FamilySearch GEDCOM 7.
+This document tracks the set of Family Events, both those in FamilySearch GEDCOM 7 and those considered for future addition.
 Guides for using this document can be found in the associated [README.md](README.md).
 
+# Table
 
-# Table of Proposals
+| G7 Tag | Since | Name | Notes |
+|:------:|-------|------|-------|
+| `ANUL` | 4.0 | [Annulment](#annulment) | |
+| `CENS` | 3.0 | Census | |
+| | | [Common Law Marriage](#common-law-marriage) | perhaps `MARR`.`TYPE Common law`? |
+| `DIV`  | 3.0 | [Divorce](#divorce) | |
+| `DIVF` | 4.0 | Divorce Filed | |
+| `ENGA` | 4.0 | Engagement | |
+| `MARR` | 3.0 | [Marriage](#marriage) | |
+| `MARB` | 4.0 | Marriage Bann | |
+| `MARL` | 4.0 | Marriage License | |
+| `MARS` | 4.0 | Marriage Settlement | |
 
-| G7 Tag | v7.x| Name           | URIs | Notes |
-|:------:|-----|----------------|------|-------|
-| `ANUL` | 7.0 | Annulment | `http://gedcomx.org/Annulment` | |
-|        |     | [Common Law Marriage](#common-law-marriage) | `http://gedcomx.org/CommonLawMarriage` | perhaps `MARR`.`TYPE Common law`? |
-| `DIV`  | 7.0 | Divorce | `http://gedcomx.org/Divorce` | |
-| `MARR` | 7.0 | Marriage | `http://gedcomx.org/Marriage` | |
+# Details
 
-# Details of Proposals
+## Annulment
 
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Annulment`
 
 ## Common Law Marriage
 
@@ -22,7 +30,7 @@ Guides for using this document can be found in the associated [README.md](README
 
 *proposed description missing*
 
-*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* " The fact of a marriage by common law."
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "The fact of a marriage by common law."
 
 ### Value
 
@@ -42,6 +50,14 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/CommonLawMarriage`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) via GEDCOM X.
+
+## Divorce
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Divorce`
+
+## Marriage
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Marriage`

--- a/attribute-event-requests/FAM-event.md
+++ b/attribute-event-requests/FAM-event.md
@@ -1,0 +1,47 @@
+# Proposed Family Events
+
+This document tracks various proposed additions to the set of Family Events in FamilySearch GEDCOM 7.
+Guides for using this document can be found in the associated [README.md](README.md).
+
+
+# Table of Proposals
+
+| G7 Tag | v7.x| Name           | URIs | Notes |
+|:------:|-----|----------------|------|-------|
+| `ANUL` | 7.0 | Annulment | `http://gedcomx.org/Annulment` | |
+|        |     | [Common Law Marriage](#common-law-marriage) | `http://gedcomx.org/CommonLawMarriage` | perhaps `MARR`.`TYPE Common law`? |
+| `DIV`  | 7.0 | Divorce | `http://gedcomx.org/Divorce` | |
+| `MARR` | 7.0 | Marriage | `http://gedcomx.org/Marriage` | |
+
+# Details of Proposals
+
+
+## Common Law Marriage
+
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* " The fact of a marriage by common law."
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- `MARR`: can express a marriage of any type, potentially including common law marriages. Common law marriages can differ from other marriages, however, in that they may lack a ceremony or event marking the entrance into the married state.
+
+Related proposals include
+
+- Lived Together (in the Family Attributes document): some interpretations of common law marriage and cohabitation are very similar to one another
+
+### Used
+
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -7,16 +7,16 @@ Guides for using this document can be found in the associated [README.md](README
 # Table of Proposals
 
 | G7 Tag | v7.x| Name           | URIs | Notes |
-|--------|-----|----------------|------|-------|
-|        |     | Affiliation | `http://familysearch.org/v1/Affiliation` | |
+|:------:|-----|----------------|------|-------|
+|        |     | [Affiliation](#affiliation) | `http://familysearch.org/v1/Affiliation` | |
 | `CAST` | 7.0 | Caste | `http://gedcomx.org/Caste` | |
 | \*     | 7.0 | Childless | `http://familysearch.org/v1/NoChildren` | in 7.0 as `NCH 0` |
-|        |     | Clan | `http://gedcomx.org/Clan` | |
+|        |     | [Clan](#clan) | `http://gedcomx.org/Clan` | |
 | \*     | 7.0 | Died Before Eight | `http://familysearch.org/v1/DiedBeforeEight` | in 7.0 as `DEAT`.`AGE <8y` |
-|        |     | Ethnicity | `http://gedcomx.org/Ethnicity` | |
-|        |     | Heimat | `http://gedcomx.org/Heimat`| |
-|        |     | Life Sketch | `http://familysearch.org/v1/LifeSketch` | |
-|        |     | Military Service | `http://gedcomx.org/MilitaryService` | |
+|        |     | [Ethnicity](#ethnicity) | `http://gedcomx.org/Ethnicity` | |
+|        |     | [Heimat](#heimat) | `http://gedcomx.org/Heimat`| |
+|        |     | [Life Sketch](#life-sketch) | `http://familysearch.org/v1/LifeSketch` | |
+|        |     | [Military Service](#military-service) | `http://gedcomx.org/MilitaryService` | |
 | `IDNO` | 7.0 | National Id | `http://gedcomx.org/NationalId` | also `SSN` for USA only |
 | `NATI` | 7.0 | Nationality | `http://gedcomx.org/Nationality` | |
 | `OCCU` | 7.0 | Occupation | `http://gedcomx.org/Occupation` | |
@@ -25,7 +25,7 @@ Guides for using this document can be found in the associated [README.md](README
 | `RESI` | 7.0 | Residence | `http://gedcomx.org/Residence` | |
 | \*     | 7.0 | Single | `http://familysearch.org/v1/NoCoupleRelationships` | in 7.0 as `NMR 0` |
 | `TITL` | 7.0 | Title | `http://familysearch.org/v1/TitleOfNobility` | |
-|        |     | Tribe | `http://gedcomx.org/Tribe`<br/>`http://familysearch.org/v1/TribeName` | |
+|        |     | [Tribe](#tribe) | `http://gedcomx.org/Tribe`<br/>`http://familysearch.org/v1/TribeName` | |
 
 # Details of Proposals
 

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -1,33 +1,37 @@
-# Proposed Individual Attributes
+# Individual Attributes
 
-This document tracks various proposed additions to the set of Individual Attributes in FamilySearch GEDCOM 7.
+This document tracks the set of Individual Attributes, both those in FamilySearch GEDCOM 7 and those considered for future addition.
 Guides for using this document can be found in the associated [README.md](README.md).
 
+# Table
 
-# Table of Proposals
+| G7 Tag | Since | Name | Notes |
+|:------:|-------|------|-------|
+| | | [Affiliation](#affiliation) | |
+| `CAST` | 5.0 | [Caste](#caste) | |
+| \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
+| | | [Clan](#clan) | |
+| \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
+| `EDUC` | 4.0 | Education | |
+| | | [Ethnicity](#ethnicity) | `http://gedcomx.org/Ethnicity` | |
+| | | [Heimat](#heimat) | `http://gedcomx.org/Heimat`| |
+| | | [Life Sketch](#life-sketch) | `http://familysearch.org/v1/LifeSketch` | |
+| | | [Military Service](#military-service) | `http://gedcomx.org/MilitaryService` | |
+| `IDNO` | 5.3 | [National ID](#national-id) | see also `SSN` |
+| `NATI` | 5.0 | [Nationality](#nationality) | |
+| `NCHI` | 5.0 | Number of Children | |
+| `NMR`  | 5.0 | Number of Marriages | really number of `FAM`s; marriage not required |
+| `OCCU` | 3.0 | [Occupation](#occupation) | |
+| `DSCR` | 5.0 | [Physical Description](#physical-description) | |
+| `PROP` | 3.0 | Property | |
+| `RELI` | 3.0 | [Religion](#religion) | |
+| `RESI` | 3.0 | [Residence](#residence) | |
+| \*     | 5.0 | [Single](#single) | encoded as `NMR 0` |
+| `SSN`  | 5.3 | Social Security Number | the USA's `IDNO` equivalent |
+| `TITL` | 3.0 | [Title](#title) | |
+| | | [Tribe](#tribe) | |
 
-| G7 Tag | v7.x| Name           | URIs | Notes |
-|:------:|-----|----------------|------|-------|
-|        |     | [Affiliation](#affiliation) | `http://familysearch.org/v1/Affiliation` | |
-| `CAST` | 7.0 | Caste | `http://gedcomx.org/Caste` | |
-| \*     | 7.0 | Childless | `http://familysearch.org/v1/NoChildren` | in 7.0 as `NCH 0` |
-|        |     | [Clan](#clan) | `http://gedcomx.org/Clan` | |
-| \*     | 7.0 | Died Before Eight | `http://familysearch.org/v1/DiedBeforeEight` | in 7.0 as `DEAT`.`AGE <8y` |
-|        |     | [Ethnicity](#ethnicity) | `http://gedcomx.org/Ethnicity` | |
-|        |     | [Heimat](#heimat) | `http://gedcomx.org/Heimat`| |
-|        |     | [Life Sketch](#life-sketch) | `http://familysearch.org/v1/LifeSketch` | |
-|        |     | [Military Service](#military-service) | `http://gedcomx.org/MilitaryService` | |
-| `IDNO` | 7.0 | National Id | `http://gedcomx.org/NationalId` | also `SSN` for USA only |
-| `NATI` | 7.0 | Nationality | `http://gedcomx.org/Nationality` | |
-| `OCCU` | 7.0 | Occupation | `http://gedcomx.org/Occupation` | |
-| `DESC` | 7.0 | Physical Description | `http://gedcomx.org/PhysicalDescription` | |
-| `RELI` | 7.0 | Religion | `http://gedcomx.org/Religion` | |
-| `RESI` | 7.0 | Residence | `http://gedcomx.org/Residence` | |
-| \*     | 7.0 | Single | `http://familysearch.org/v1/NoCoupleRelationships` | in 7.0 as `NMR 0` |
-| `TITL` | 7.0 | Title | `http://familysearch.org/v1/TitleOfNobility` | |
-|        |     | [Tribe](#tribe) | `http://gedcomx.org/Tribe`<br/>`http://familysearch.org/v1/TribeName` | |
-
-# Details of Proposals
+# Details
 
 
 ## Affiliation
@@ -59,9 +63,24 @@ Related proposals include
 
 ### Used
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/Affiliation`
 
 
+
+## Caste
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Caste`
+
+
+## Childless
+
+The assertion that a family does not have children can be made using the `NCHI` structure with payload "`0`".
+This is distinct from simply not having any `CHIL` structures,
+which might mean there are children that have not yet been added to the data.
+
+### Used
+
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as a distinct stucture with URI `http://familysearch.org/v1/CoupleNeverHadChildren`
 
 
 ## Clan
@@ -93,10 +112,18 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Clan`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) via GEDCOM X.
 
+
+## Died Before Eight
+
+The assertion that a person died before the end of their eighth year of life can be made using the `DEAT` structure with an `AGE` substructure with payload "`< 8y`".
+
+### Used
+
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/DiedBeforeEight`
 
 
 ## Ethnicity
@@ -128,9 +155,9 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Ethnicity`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) via GEDCOM X.
 
 
 ## Heimat
@@ -163,7 +190,7 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Heimat`
   
   *Not* used by the FamilySearch API, the GEDCOM-X implementation with the largest user base; see <https://www.familysearch.org/developers/docs/guides/facts>
 
@@ -193,7 +220,7 @@ There are no similar proposals here.
 
 ### Used
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/LifeSketch`
 - Used by Ancestry, under the name "Life Story"
 - Used by FindAGrave, under the name "Bio Information"
 
@@ -231,12 +258,50 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/MilitaryService`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) via GEDCOM X.
 
 
 
+
+## National ID
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/NationalId`
+
+## Nationality
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Nationality`
+
+## Occupation
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Occupation`
+
+## Physical Description
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/PhysicalDescription`
+
+## Religion
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Religion`
+
+## Residence
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Residence`
+
+## Single
+
+The assertion that a person is not a partner in a family can be made using the `NMR` structure with payload "`0`".
+This is distinct from simply not having any `FAMS` structures,
+which might mean there are relationships that have not yet been added to the data.
+
+### Used
+
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/NoCoupleRelationships`
+
+## Title
+
+In [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/TitleOfNobility`
 
 
 
@@ -271,6 +336,6 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Tribe`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/TribeName`

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -1,0 +1,274 @@
+# Proposed Individual Attributes
+
+This document tracks various proposed additions to the set of Individual Attributes in FamilySearch GEDCOM 7.
+Guides for using this document can be found in the associated [README.md](README.md).
+
+
+# Table of Proposals
+
+| G7 Tag | v7.x| Name           | URIs | Notes |
+|--------|-----|----------------|------|-------|
+|        |     | Affiliation | `http://familysearch.org/v1/Affiliation` | |
+| `CAST` | 7.0 | Caste | `http://gedcomx.org/Caste` | |
+| \*     | 7.0 | Childless | `http://familysearch.org/v1/NoChildren` | in 7.0 as `NCH 0` |
+|        |     | Clan | `http://gedcomx.org/Clan` | |
+| \*     | 7.0 | Died Before Eight | `http://familysearch.org/v1/DiedBeforeEight` | in 7.0 as `DEAT`.`AGE <8y` |
+|        |     | Ethnicity | `http://gedcomx.org/Ethnicity` | |
+|        |     | Heimat | `http://gedcomx.org/Heimat`| |
+|        |     | Life Sketch | `http://familysearch.org/v1/LifeSketch` | |
+|        |     | Military Service | `http://gedcomx.org/MilitaryService` | |
+| `IDNO` | 7.0 | National Id | `http://gedcomx.org/NationalId` | also `SSN` for USA only |
+| `NATI` | 7.0 | Nationality | `http://gedcomx.org/Nationality` | |
+| `OCCU` | 7.0 | Occupation | `http://gedcomx.org/Occupation` | |
+| `DESC` | 7.0 | Physical Description | `http://gedcomx.org/PhysicalDescription` | |
+| `RELI` | 7.0 | Religion | `http://gedcomx.org/Religion` | |
+| `RESI` | 7.0 | Residence | `http://gedcomx.org/Residence` | |
+| \*     | 7.0 | Single | `http://familysearch.org/v1/NoCoupleRelationships` | in 7.0 as `NMR 0` |
+| `TITL` | 7.0 | Title | `http://familysearch.org/v1/TitleOfNobility` | |
+|        |     | Tribe | `http://gedcomx.org/Tribe`<br/>`http://familysearch.org/v1/TribeName` | |
+
+# Details of Proposals
+
+
+## Affiliation
+
+### Description
+
+*proposed description missing*
+
+*In [FamilySearch API documentation](https://www.familysearch.org/developers/docs/guides/facts)* without a definition
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- Clan: *difference from Affiliation not yet articulated*
+- Tribe: *difference from Affiliation not yet articulated*
+- Ethnicity: *difference from Affiliation not yet articulated*
+- Heimat: *difference from Affiliation not yet articulated*
+
+### Used
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+
+
+
+
+## Clan
+
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's clan."
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- Tribe: *difference from Clan not yet articulated*
+- Ethnicity: *difference from Clan not yet articulated*
+- Heimat: a place, often as a disambiguation of family name or lineage. Clan suggests group identity, not geography
+- Affiliation: generally by choice or appointment, while clan generally indicates something assigned to a person at birth
+
+### Used
+
+- Part of the GEDCOM X specification
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+
+
+
+## Ethnicity
+
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's ethnicity."
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- Tribe: *difference from Ethnicity not yet articulated*
+- Clan: *difference from Ethnicity not yet articulated*
+- Heimat: a place, often as a disambiguation of family name or lineage. Ethnicity suggests group identity, not geography
+- Affiliation: generally an organized group by choice or appointment, while ethnicity generally indicates a broader culture my self-identification
+
+### Used
+
+- Part of the GEDCOM X specification
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+
+
+## Heimat
+
+### Description
+
+A geographic place to which a person is affiliated by birth or ancestry, but not necessarily by residence or property.
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's _heimat_. "Heimat" refers to a person's affiliation by birth to a specific geographic place. Distinct heimaten are often useful as indicators that two persons of the same name are not likely to be closely related genealogically. In English, "heimat" may be described using terms like "ancestral home", "homeland", or "place of origin".
+
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- Ethnicity: ethnicities typically have some geographic association, but generally much larger and less fine-grained than a heimat
+- Tribe: members of a tribe may share a heimat, but tribes may be defined by other characteristics too
+- Clan: members of a clan may share a heimat, but clans may be defined by other characteristics too
+- Affiliation: a person with a given heimat needn't have any affiliation with others with the same heimat
+
+### Used
+
+- Part of the GEDCOM X specification (but not used by the FamilySearch API, the GEDCOM-X implementation with the largest user base; see <https://www.familysearch.org/developers/docs/guides/facts>)
+
+
+
+## Life Sketch
+
+### Description
+
+*proposed description missing*
+
+*In [FamilySearch API documentation](https://www.familysearch.org/developers/docs/guides/facts)* without a definition
+
+### Value
+
+Found in the following historical records:
+
+- 
+
+### Absence
+
+The most closely related structures are:
+
+- `NOTE`: a life sketch is not a historical attribute in the usual sense (it lacks a date, place, associated individuals, etc). There is a proposal ([issue #219](https://github.com/FamilySearch/GEDCOM/issues/219)) to add note type to cover this instead of a new attribute.
+
+There are no similar proposals here.
+
+### Used
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by Ancestry, under the name "Life Story"
+- Used by FindAGrave, under the name "Bio Information"
+
+
+
+
+## Military Service
+
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's military service."
+
+### Value
+
+Found in the following historical records:
+
+- Military induction papers
+- Military records
+- Military discharge papers
+- Military awards and recognitions
+- Veteran registries and group memberships
+- Private journals, biographies, and obituaries
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- GEDCOM-X has events "Military Induction" and "Military Discharge" which define the start and end of the military service
+
+### Used
+
+- Part of the GEDCOM X specification
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+
+
+
+
+
+
+## Tribe
+
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's tribe."
+
+*In [FamilySearch API documentation](https://www.familysearch.org/developers/docs/guides/facts)* without a definition, and with a different URI than that used by GEDCOM-X
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- 
+
+Related proposals include
+
+- Clan: *difference from Tribe not yet articulated*
+- Ethnicity: *difference from Tribe not yet articulated*
+- Heimat: a place, often as a disambiguation of family name or lineage. Tribe suggests group identity, not geography
+- Affiliation: generally by choice or appointment, while tribe generally indicates something assigned to a person at birth
+
+### Used
+
+- Part of the GEDCOM X specification
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -13,10 +13,10 @@ Guides for using this document can be found in the associated [README.md](README
 | | | [Clan](#clan) | |
 | \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
 | `EDUC` | 4.0 | Education | |
-| | | [Ethnicity](#ethnicity) | `http://gedcomx.org/Ethnicity` | |
-| | | [Heimat](#heimat) | `http://gedcomx.org/Heimat`| |
-| | | [Life Sketch](#life-sketch) | `http://familysearch.org/v1/LifeSketch` | |
-| | | [Military Service](#military-service) | `http://gedcomx.org/MilitaryService` | |
+| | | [Ethnicity](#ethnicity) | |
+| | | [Heimat](#heimat) | |
+| | | [Life Sketch](#life-sketch) | |
+| | | [Military Service](#military-service) | |
 | `IDNO` | 5.3 | [National ID](#national-id) | see also `SSN` |
 | `NATI` | 5.0 | [Nationality](#nationality) | |
 | `NCHI` | 5.0 | Number of Children | |

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -93,7 +93,7 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
 
 - Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
 
@@ -128,7 +128,7 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
 
 - Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
 
@@ -163,7 +163,9 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification (but not used by the FamilySearch API, the GEDCOM-X implementation with the largest user base; see <https://www.familysearch.org/developers/docs/guides/facts>)
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+  
+  *Not* used by the FamilySearch API, the GEDCOM-X implementation with the largest user base; see <https://www.familysearch.org/developers/docs/guides/facts>
 
 
 
@@ -229,7 +231,7 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
 
 - Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
 
@@ -269,6 +271,6 @@ Related proposals include
 
 ### Used
 
-- Part of the GEDCOM X specification
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
 
 - Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>

--- a/attribute-event-requests/INDI-event.md
+++ b/attribute-event-requests/INDI-event.md
@@ -7,7 +7,7 @@ Guides for using this document can be found in the associated [README.md](README
 # Table of Proposals
 
 | G7 Tag | v7.x| Name           | URIs | Notes |
-|--------|-----|----------------|------|-------|
+|:------:|-----|----------------|------|-------|
 | `BARM` | 7.0 | Bar Mitzvah    | `http://gedcomx.org/BarMitzvah` | |
 | `BASM` | 7.0 | Bat Mitzvah    | `http://gedcomx.org/BatMitzvah` | |
 | `BIRT` | 7.0 | Birth          | `http://gedcomx.org/Birth` | |
@@ -17,7 +17,7 @@ Guides for using this document can be found in the associated [README.md](README
 | `DEAT` | 7.0 | Death          | `http://gedcomx.org/Death` | |
 | `IMMI` | 7.0 | Immigration    | `http://gedcomx.org/Immigration` | |
 | `NATU` | 7.0 | Naturalization | `http://gedcomx.org/Naturalization` | |
-|        |     | Stillbirth     | `http://gedcomx.org/Stillbirth` | perhaps `BIRT`.`TYPE Stillborn` or `DEAT`.`AGE 0y`? |
+|        |     | [Stillbirth](#stillbirth) | `http://gedcomx.org/Stillbirth` | perhaps `BIRT`.`TYPE Stillborn` or `DEAT`.`AGE 0y`? |
 
 # Details of Proposals
 

--- a/attribute-event-requests/INDI-event.md
+++ b/attribute-event-requests/INDI-event.md
@@ -1,25 +1,79 @@
-# Proposed Individual Events
+# Individual Events
 
-This document tracks various proposed additions to the set of Individual Events in FamilySearch GEDCOM 7.
+This document tracks the set of Individual Events, both those in FamilySearch GEDCOM 7 and those considered for future addition.
 Guides for using this document can be found in the associated [README.md](README.md).
 
+# Table
 
-# Table of Proposals
+| G7 Tag | Since | Name | Notes |
+|:------:|-------|------|-------|
+| `ADOP` | 3.0 | Adoption | |
+| `CHRA` | 5.0 | Adult Christening | |
+| `BAPM` | 3.0 | Baptism | |
+| `BARM` | 4.0 | [Bar Mitzvah](#bar-mitzvah) | |
+| `BASM` | 4.0 | [Bat Mitzvah](#bat-mitzvah) | |
+| `BIRT` | 3.0 | [Birth](#birth) | |
+| `BLES` | 3.0 | Blessing | |
+| `BURI` | 3.0 | [Burial](#burial) | |
+| `CENS` | 3.0 | Census | |
+| `CHR`  | 3.0 | [Christening](#christening) | |
+| `CONF` | 3.0 | Confirmation | |
+| `CREM` | 5.4 | [Cremation](#cremation) | |
+| `DEAT` | 3.0 | [Death](#death) | |
+| `EMIG` | 3.0 | Emigration | |
+| `FCOM` | 4.0 | First Communion | |
+| `GRAD` | 4.0 | Graduation | |
+| `IMMI` | 3.0 | [Immigration](#immigration) | |
+| `NATU` | 3.0 | [Naturalization](#naturalization) | |
+| `ORDN` | 3.0 | Ordination | |
+| `PROB` | 3.0 | Probate | |
+| `RETI` | 4.0 | Retirement | |
+| | | [Stillbirth](#stillbirth) | perhaps `BIRT`.`TYPE Stillborn` or `DEAT`.`AGE 0y`? |
+| `WILL` | 3.0 | Will  | |
 
-| G7 Tag | v7.x| Name           | URIs | Notes |
-|:------:|-----|----------------|------|-------|
-| `BARM` | 7.0 | Bar Mitzvah    | `http://gedcomx.org/BarMitzvah` | |
-| `BASM` | 7.0 | Bat Mitzvah    | `http://gedcomx.org/BatMitzvah` | |
-| `BIRT` | 7.0 | Birth          | `http://gedcomx.org/Birth` | |
-| `BURI` | 7.0 | Burial         | `http://gedcomx.org/Burial` | |
-| `CHR`  | 7.0 | Christening    | `http://gedcomx.org/Christening` | |
-| `CREM` | 7.0 | Cremation      | `http://gedcomx.org/Cremation` | |
-| `DEAT` | 7.0 | Death          | `http://gedcomx.org/Death` | |
-| `IMMI` | 7.0 | Immigration    | `http://gedcomx.org/Immigration` | |
-| `NATU` | 7.0 | Naturalization | `http://gedcomx.org/Naturalization` | |
-|        |     | [Stillbirth](#stillbirth) | `http://gedcomx.org/Stillbirth` | perhaps `BIRT`.`TYPE Stillborn` or `DEAT`.`AGE 0y`? |
 
-# Details of Proposals
+# Details
+
+## Bar Mitzvah
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/BarMitzvah`
+
+## Bat Mitzvah
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/BatMitzvah`
+
+## Birth
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Birth`
+
+## Burial
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Burial`
+
+## Christening
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Christening`
+
+## Cremation
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Cremation`
+
+## Death
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Death`
+
+## Immigration
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Immigration`
+
+## Naturalization
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Naturalization`
+
+## Religion
+
+In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Religion`
+
 
 ## Stillbirth
 
@@ -46,7 +100,7 @@ There are no similar proposals here.
 
 ### Used
 
-- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/BarMitzvah`
 
-- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) via GEDCOM X
 

--- a/attribute-event-requests/INDI-event.md
+++ b/attribute-event-requests/INDI-event.md
@@ -1,0 +1,52 @@
+# Proposed Individual Events
+
+This document tracks various proposed additions to the set of Individual Events in FamilySearch GEDCOM 7.
+Guides for using this document can be found in the associated [README.md](README.md).
+
+
+# Table of Proposals
+
+| G7 Tag | v7.x| Name           | URIs | Notes |
+|--------|-----|----------------|------|-------|
+| `BARM` | 7.0 | Bar Mitzvah    | `http://gedcomx.org/BarMitzvah` | |
+| `BASM` | 7.0 | Bat Mitzvah    | `http://gedcomx.org/BatMitzvah` | |
+| `BIRT` | 7.0 | Birth          | `http://gedcomx.org/Birth` | |
+| `BURI` | 7.0 | Burial         | `http://gedcomx.org/Burial` | |
+| `CHR`  | 7.0 | Christening    | `http://gedcomx.org/Christening` | |
+| `CREM` | 7.0 | Cremation      | `http://gedcomx.org/Cremation` | |
+| `DEAT` | 7.0 | Death          | `http://gedcomx.org/Death` | |
+| `IMMI` | 7.0 | Immigration    | `http://gedcomx.org/Immigration` | |
+| `NATU` | 7.0 | Naturalization | `http://gedcomx.org/Naturalization` | |
+|        |     | Stillbirth     | `http://gedcomx.org/Stillbirth` | perhaps `BIRT`.`TYPE Stillborn` or `DEAT`.`AGE 0y`? |
+
+# Details of Proposals
+
+## Stillbirth
+
+### Description
+
+Born dead or died shortly after birth (exact definitions vary by culture and time period).
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's stillbirth."
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- `DEAT`.`AGE`: can express any specific meaning (`< 0y`, `< 0d`, etc), and had a special value for "stillborn" in 5.5.1 and before: that special value was removed from `AGE` payloads in 7.0 because it was not a valid age in any other context.
+- `BIRT`.`TYPE`: can provide a user-language-specific indication of stillbirth; this is used as an example of `TYPE` in the 7.0 specification.
+
+There are no similar proposals here.
+
+### Used
+
+- Part of the GEDCOM X specification <https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md>
+
+- Used by the FamilySearch API <https://www.familysearch.org/developers/docs/guides/facts>
+

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -1,6 +1,8 @@
-# Proposed new Family and Individual Attributes and Events
+# Proposing new Family and Individual Attributes and Events
 
 The documents in this folder track various proposed additions to the set of Family Attributes, Family Events, Individual Attributes, and Individual Events in FamilySearch GEDCOM 7.
+It includes all current structures of those types for ease of reference.
+It may include links to other systems or standards that use these structures in ways other than GEDCOM when such uses have been identified and contributed here.
 
 There is an inherent tension between completeness (which would recommend including every event and attribute type we can define) and simplicity (which would recommend including only a few of the the most important options). In 2023. the GEDCOM Steering Committee identified the following criteria for a proposal to be added to the specification.
 
@@ -21,36 +23,42 @@ It may be that some of the event and attribute types in 7.0 were included becaus
 Each of the other four documents in this folder are structured as follows:
 
 1. A brief opening, pointing back to this document.
-2. A table of the major proposals in the document.
-3. A section for each proposal that is not yet in the specification, with evidence of the three criteria above
+2. A table of the current and proposed structure types discussed in the document.
+3. A section for those proposals for which additional information has been supplied.
 
-To propose, support, or oppose the addition of a new structure type to a future version of FamilySearch GEDCOM 7, please submit a **pull request** editing the appropriate document. If you are not comfortable submitting a pull request, an **issue** or **discussion** can be used instead.
+To propose, support, or oppose the addition of a new structure type to a future version of FamilySearch GEDCOM 7, please submit a [pull request](https://github.com/FamilySearch/GEDCOM/pulls) editing the appropriate document. If you are not comfortable submitting a pull request, an [issue](https://github.com/FamilySearch/GEDCOM/issues) or [discussion](https://github.com/FamilySearch/GEDCOM/discussions) can be used instead.
+
+If there is no document here for the type of structure you want to suggest, please use the [issues tracker](https://github.com/FamilySearch/GEDCOM/issues) instead.
 
 ## Guide on the table
 
-Each proposal should have one row in the table, with five cells:
+Each proposal should have one row in the table, with four cells:
 
-1. **G7 Tag** is set only once present in the specification. The special value "\*" is used to indicate attributes or events that are present in a different way, such 
+1. **G7 Tag** is set only once present in the specification.
+    
+    The special value "\*" is used to indicate attributes or events that are present in a different way, such as with a set of structures and payloads.
 
-2. **v7.x** is set only once present in the specification
+2. **Since** is set only once present in the specification, and identifies which version of GEDCOM first provided the structure.
+    
+    If the structure was provided in an earlier version of GEDCOM but removed before the current version, the *since* field is left blank.
 
-3. **Name** is a proposed short English name (suitable for use in a label). If the concept is uncommon in English-speaking cultures, the name may be that used in the language of a culture where it is common, transliterated into the Latin script as needed.
+3. **Name** is a short English name (suitable for use in a label) for the event or attribute type. If the concept is uncommon in English-speaking cultures, the name may be that used in the language of a culture where it is common, transliterated into the Latin script as needed.
+    
+    If there is a subsection for this structure in the details section, make this a hyperlink to it by
+    
+    - making a slug from the name by
+        - lower-casing the name
+        - replacing non-alphanumeric characters with hyphens
+    - putting the name in brackets, then putting in parentheses a hash and the slug, like `[Name](#name)`
 
-4. **URIs** is the concept's identifiers from other specifications, such as GEDCOM-X, FamilySearch API, etc. If several, the markdown should have them on one line separated by line break tags, like this:
-
-    ````
-    | | | Example | `http://example.com/uri1`<br/>`http://example.com/uri2` | |
-    ````
-
-5. **Notes** about other ways this information is encoded in FamilySearch GEDCOM 7 (other than as an event or attribute)
-
-When an event or attribute type that is part of GEDCOM is present in a family history system that does not use GEDCOM, it is appropriate to include it in the table to make the relationship to GEDCOM explicit.
+4. **Notes** clarifying the first three cells, such as explaining which structures are used if the tag was "\*" or noting a difference between name and meaning.
 
 ## Guide on the per-proposal sections
 
 Open with the same header as a **Name** field in the table, preceded by two hashtags, like `## Example`
 
-Have the following subsections:
+Structure types that are already part of the GEDCOM specification may contain just a list of ways the same structure is referenced in other (non-GEDCOM) formats and tools.
+All other structure types should have the following subsections:
 
 1. `### Description`
 

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -1,0 +1,88 @@
+# Proposed new Family and Individual Attributes and Events
+
+The documents in this folder track various proposed additions to the set of Family Attributes, Family Events, Individual Attributes, and Individual Events in FamilySearch GEDCOM 7.
+
+There is an inherent tension between completeness (which would recommend including every event and attribute type we can define) and simplicity (which would recommend including only a few of the the most important options). In 2023. the GEDCOM Steering Committee identified the following criteria for a proposal to be added to the specification.
+
+In general, events and attribute are accepted for inclusion once the following criteria are met:
+
+1. **Valuable**: they are present in historical records and are either defining aspects of a person's life or otherwise important for informing research or creating life summaries
+
+2. **Absent**: they are meaningfully distinct from, and not merely a more detailed subtype of, existing structure types
+
+3. **Used**: multiple family history applications with active user bases either use it now or have expressed a desire to add it as soon as it is available in the standard
+
+New events and attributes are added in minor versions (7.1, 7.2, etc.).
+Old events and attributes can be deprecated at any time, but can only be removed in major versions (8.0, 9.0, etc.)
+It may be that some of the event and attribute types in 7.0 were included because they were also in 5.5.1 and do not meet these criteria and may be removed in 8.0 or beyond.
+
+# Directions for using the documents in this folder
+
+Each of the other four documents in this folder are structured as follows:
+
+1. A brief opening, pointing back to this document.
+2. A table of the major proposals in the document.
+3. A section for each proposal that is not yet in the specification, with evidence of the three criteria above
+
+To propose, support, or oppose the addition of a new structure type to a future version of FamilySearch GEDCOM 7, please submit a **pull request** editing the appropriate document. If you are not comfortable submitting a pull request, an **issue** or **discussion** can be used instead.
+
+## Guide on the table
+
+Each proposal should have one row in the table, with five cells:
+
+1. **G7 Tag** is set only once present in the specification. The special value "\*" is used to indicate attributes or events that are present in a different way, such 
+
+2. **v7.x** is set only once present in the specification
+
+3. **Name** is a proposed short English name (suitable for use in a label). If the concept is uncommon in English-speaking cultures, the name may be that used in the language of a culture where it is common, transliterated into the Latin script as needed.
+
+4. **URIs** is the concept's identifiers from other specifications, such as GEDCOM-X, FamilySearch API, etc. If several, the markdown should have them on one line separated by line break tags, like this:
+
+    ````
+    | | | Example | `http://example.com/uri1`<br/>`http://example.com/uri2` | |
+    ````
+
+5. **Notes** about other ways this information is encoded in FamilySearch GEDCOM 7 (other than as an event or attribute)
+
+When an event or attribute type is present in a family history system that does not use GEDCOM, it is appropriate to include it in the table to make the relationship to GEDCOM explicit.
+
+## Guide on the per-proposal sections
+
+Open with the same header as a **Name** field in the table, preceded by two hashtags, like `## Example`
+
+Have the following subsections:
+
+1. `### Description`
+
+    A succinct but clear description such as might go in the specification if accepted.
+    
+    *In [specification X](https://example.com/specificationx.html> as* "The description used by specification X"
+
+2. `### Value`
+
+    Found in the following historical records:
+    
+    - A list of records that include it, such as
+    - US Census, 1880 through 1940
+    - Swedish grave markers, circa 1400
+    
+    Any additional explanation of value, such as how it is used to inform research or display information.
+    
+3. `### Absence`
+
+    The most closely related structures are:
+    
+    - `TAG`: description of similarity and difference
+    
+    Related proposals include
+
+    - Name: description of similarity and difference
+
+4. `### Used`
+
+    - *Application name* currently uses this in its user interface and internal file format, but removes it during GEDCOM export
+    
+    - *Application name* exports this with an `EVEN` tag with `TYPE whatever`
+
+    - *Application name* exports this with an extension tag `_EX`, defined in <https://example.com/defining/EX.yaml>
+

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -44,7 +44,7 @@ Each proposal should have one row in the table, with five cells:
 
 5. **Notes** about other ways this information is encoded in FamilySearch GEDCOM 7 (other than as an event or attribute)
 
-When an event or attribute type is present in a family history system that does not use GEDCOM, it is appropriate to include it in the table to make the relationship to GEDCOM explicit.
+When an event or attribute type that is part of GEDCOM is present in a family history system that does not use GEDCOM, it is appropriate to include it in the table to make the relationship to GEDCOM explicit.
 
 ## Guide on the per-proposal sections
 

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -18,7 +18,7 @@ New events and attributes are added in minor versions (7.1, 7.2, etc.).
 Old events and attributes can be deprecated at any time, but can only be removed in major versions (8.0, 9.0, etc.)
 It may be that some of the event and attribute types in 7.0 were included because they were also in 5.5.1 and do not meet these criteria and may be removed in 8.0 or beyond.
 
-# Directions for using the documents in this folder
+# Using the documents in this folder
 
 Each of the other four documents in this folder are structured as follows:
 

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -64,7 +64,7 @@ All other structure types should have the following subsections:
 
     A succinct but clear description such as might go in the specification if accepted.
     
-    *In [specification X](https://example.com/specificationx.html> as* "The description used by specification X"
+    *In [specification X](https://example.com/specificationx.html) as* "The description used by specification X"
 
 2. `### Value`
 

--- a/attribute-event-requests/README.md
+++ b/attribute-event-requests/README.md
@@ -4,7 +4,7 @@ The documents in this folder track various proposed additions to the set of Fami
 It includes all current structures of those types for ease of reference.
 It may include links to other systems or standards that use these structures in ways other than GEDCOM when such uses have been identified and contributed here.
 
-There is an inherent tension between completeness (which would recommend including every event and attribute type we can define) and simplicity (which would recommend including only a few of the the most important options). In 2023. the GEDCOM Steering Committee identified the following criteria for a proposal to be added to the specification.
+There is an inherent tension between completeness (which would recommend including every event and attribute type we can define) and simplicity (which would recommend including only a few of the the most important options). In 2023, the GEDCOM Steering Committee identified the following criteria for a proposal to be added to the specification.
 
 In general, events and attribute are accepted for inclusion once the following criteria are met:
 


### PR DESCRIPTION
This adds to the repository a set of documents where we can track the pros and cons of the 100+ events and attributes proposed in #117, along with a place to document the criteria we use to decide what should be included and what should not. It does not make any changes to the specification itself.

This PR also initializes the tracking documents with the event and attribute types found in the FamilySearch API documentation, for no better reason than that I happen to be working with that in my own code lately so it's fresh on my mind. If we like it we'd of course add many more proposals to the documents in the future.