### PR TITLE
gedcom-06-calendars.md: Correct adjective agreement in French Revolutionary Calendar

### DIFF
--- a/specification/gedcom-06-calendars.md
+++ b/specification/gedcom-06-calendars.md
@@ -58,21 +58,21 @@ The French Republican calendar or French Revolutionary calendar are the names gi
 
 Permitted months are
 
-|Code  |Name                |
-|:-----|:-------------------|
-|`VEND`|Vendémiaire         |
-|`BRUM`|Brumaire            |
-|`FRIM`|Frimaire            |
-|`NIVO`|Nivôse              |
-|`PLUV`|Pluviôse            |
-|`VENT`|Ventôse             |
-|`GERM`|Germinal            |
-|`FLOR`|Floréal             |
-|`PRAI`|Prairial            |
-|`MESS`|Messidor            |
-|`THER`|Thermidor           |
-|`FRUC`|Fructidor           |
-|`COMP`|Jour Complémentaires|
+|Code  |Name                 |
+|:-----|:--------------------|
+|`VEND`|Vendémiaire          |
+|`BRUM`|Brumaire             |
+|`FRIM`|Frimaire             |
+|`NIVO`|Nivôse               |
+|`PLUV`|Pluviôse             |
+|`VENT`|Ventôse              |
+|`GERM`|Germinal             |
+|`FLOR`|Floréal              |
+|`PRAI`|Prairial             |
+|`MESS`|Messidor             |
+|`THER`|Thermidor            |
+|`FRUC`|Fructidor            |
+|`COMP`|Jours complémentaires|
 
 No epoch marker is permitted in this calendar.
 


### PR DESCRIPTION
I propose a minor spelling correction in the Calendars specification. In French, adjectives must agree with nouns as to gender and whether singular/plural. The current spelling, "Jour Complémentaires," uses a singular noun and a plural adjective. I propose using "Jours complémentaires," as this would refer collectively to this period in a year, rather than just one day in that period (which would be "jour complémentaire").

<https://fr.wikipedia.org/wiki/Jour_compl%C3%A9mentaire>

I also extended the remainder of the table out by one space/hyphen for consistency.