### PR TITLE
NATI covers several gx fact types

### DIFF
--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -10,11 +10,11 @@ Guides for using this document can be found in the associated [README.md](README
 | | | [Affiliation](#affiliation) | |
 | `CAST` | 5.0 | [Caste](#caste) | |
 | \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
-| | | [Clan](#clan) | |
+| | | [Clan](#clan) | perhaps `NATI`? |
 | \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
 | `EDUC` | 4.0 | Education | |
-| | | [Ethnicity](#ethnicity) | |
-| | | [Heimat](#heimat) | |
+| | | [Ethnicity](#ethnicity) | perhaps `NATI`? |
+| | | [Heimat](#heimat) | perhaps `NATI`? |
 | `IDNO` | 5.3 | [Identifying Number](#identifying-number) | |
 | | | [Life Sketch](#life-sketch) | |
 | | | [Military Service](#military-service) | |
@@ -30,7 +30,7 @@ Guides for using this document can be found in the associated [README.md](README
 | \*     | 5.0 | [Single](#single) | encoded as `NMR 0` |
 | `SSN`  | 5.3 | Social Security Number | the USA's `IDNO` equivalent |
 | `TITL` | 3.0 | [Title](#title) | |
-| | | [Tribe](#tribe) | |
+| | | [Tribe](#tribe) | perhaps `NATI`? |
 
 # Details
 
@@ -102,7 +102,7 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- 
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." While "clan" is not specifically included, it is related to "folk", "house", "kindred", and "tribe" which are.
 
 Related proposals include
 
@@ -145,7 +145,7 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- 
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." While "ethnicity" is not specifically included, it is related to "origin", "kindred", and "lineage" which are.
 
 Related proposals include
 
@@ -180,7 +180,7 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- 
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." While "heimat" is not specifically included, it is related to "origin" and "house" which are.
 
 Related proposals include
 
@@ -331,7 +331,7 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- 
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." "Tribe" is directly listed, but in the phrase "tribal interest" which might suggest a broader definition that "tribe" does by itself.
 
 Related proposals include
 

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -182,7 +182,7 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." While "heimat" is not specifically included, it is related to "origin" and "house" which are.
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." In contrast, "heimat" refers to a geographical region a person is from.
 
 Related proposals include
 

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -10,16 +10,16 @@ Guides for using this document can be found in the associated [README.md](README
 | | | [Affiliation](#affiliation) | |
 | `CAST` | 5.0 | [Caste](#caste) | |
 | \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
-| | | [Clan](#clan) | perhaps `NATI`? |
+| `NATI` | 7.0 | [Clan](#clan) | one of several types of `NATI` |
 | \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
 | `EDUC` | 4.0 | Education | |
-| | | [Ethnicity](#ethnicity) | perhaps `NATI`? |
-| | | [Heimat](#heimat) | perhaps `NATI`? |
+| `NATI` | 5.4 | [Ethnicity](#ethnicity) | one of several types of `NATI` |
+| `NATI` | 5.4 | [Heimat](#heimat) | one of several types of `NATI` |
 | `IDNO` | 5.3 | [Identifying Number](#identifying-number) | |
 | | | [Life Sketch](#life-sketch) | |
 | | | [Military Service](#military-service) | |
 | `IDNO` | 5.3 | [National ID](#national-id) | see also `SSN` |
-| `NATI` | 5.0 | [Nationality](#nationality) | |
+| `NATI` | 5.0 | [Nationality](#nationality) | one of several types of `NATI` |
 | `NCHI` | 5.0 | Number of Children | |
 | `NMR`  | 5.0 | Number of Marriages | really number of `FAM`s; marriage not required |
 | `OCCU` | 3.0 | [Occupation](#occupation) | |
@@ -30,7 +30,7 @@ Guides for using this document can be found in the associated [README.md](README
 | \*     | 5.0 | [Single](#single) | encoded as `NMR 0` |
 | `SSN`  | 5.3 | Social Security Number | the USA's `IDNO` equivalent |
 | `TITL` | 3.0 | [Title](#title) | |
-| | | [Tribe](#tribe) | perhaps `NATI`? |
+| `NATI` | 5.4 | [Tribe](#tribe) | one of several types of `NATI` |
 
 # Details
 
@@ -107,6 +107,7 @@ The most closely related structures are:
 Related proposals include
 
 - Tribe: *difference from Clan not yet articulated*
+- Nationality: *difference from Clan not yet articulated*
 - Ethnicity: *difference from Clan not yet articulated*
 - Heimat: a place, often as a disambiguation of family name or lineage. Clan suggests group identity, not geography
 - Affiliation: generally by choice or appointment, while clan generally indicates something assigned to a person at birth
@@ -150,6 +151,7 @@ The most closely related structures are:
 Related proposals include
 
 - Tribe: *difference from Ethnicity not yet articulated*
+- Nationality: *difference from Ethnicity not yet articulated*
 - Clan: *difference from Ethnicity not yet articulated*
 - Heimat: a place, often as a disambiguation of family name or lineage. Ethnicity suggests group identity, not geography
 - Affiliation: generally an organized group by choice or appointment, while ethnicity generally indicates a broader culture my self-identification
@@ -185,6 +187,7 @@ The most closely related structures are:
 Related proposals include
 
 - Ethnicity: ethnicities typically have some geographic association, but generally much larger and less fine-grained than a heimat
+- Nationality: generally broader than heimat in what region it covers
 - Tribe: members of a tribe may share a heimat, but tribes may be defined by other characteristics too
 - Clan: members of a clan may share a heimat, but clans may be defined by other characteristics too
 - Affiliation: a person with a given heimat needn't have any affiliation with others with the same heimat
@@ -277,7 +280,37 @@ A special case of [Identifying number](#identifying-number)
 
 ## Nationality
 
-In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Nationality`
+### Description
+
+*proposed description missing*
+
+*In [GEDCOM X](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) as* "A fact of a person's nationality."
+
+### Value
+
+Found in the following historical records:
+
+- (records not yet identified)
+
+### Absence
+
+The most closely related structures are:
+
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." "National heritage or origin" is directly listed as one of several types of `NATI`.
+
+Related proposals include
+
+- Clan: *difference from Nationality not yet articulated*
+- Tribe: *difference from Nationality not yet articulated*
+- Ethnicity: *difference from Nationality not yet articulated*
+- Heimat: a place, often as a disambiguation of family name or lineage. Nationality suggests political identity, not geography
+- Affiliation: generally by choice or appointment, while nationality generally indicates something assigned by a political body
+
+### Used
+
+- Part of the [GEDCOM X specification](https://github.com/FamilySearch/gedcomx/blob/master/specifications/fact-types-specification.md) with URI `http://gedcomx.org/Nationality`
+
+- Used by the [FamilySearch API](https://www.familysearch.org/developers/docs/guides/facts) with URI `http://familysearch.org/v1/Nationality`
 
 ## Occupation
 
@@ -331,11 +364,12 @@ Found in the following historical records:
 
 The most closely related structures are:
 
-- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." "Tribe" is directly listed, but in the phrase "tribal interest" which might suggest a broader definition that "tribe" does by itself.
+- `NATI`: Defined as "an individual’s national heritage or origin, or other folk, house, kindred, lineage, or tribal interest." "Tribe" is directly listed as one of several types of `NATI`.
 
 Related proposals include
 
 - Clan: *difference from Tribe not yet articulated*
+- Nationality: *difference from Tribe not yet articulated*
 - Ethnicity: *difference from Tribe not yet articulated*
 - Heimat: a place, often as a disambiguation of family name or lineage. Tribe suggests group identity, not geography
 - Affiliation: generally by choice or appointment, while tribe generally indicates something assigned to a person at birth

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -10,7 +10,7 @@ Guides for using this document can be found in the associated [README.md](README
 | | | [Affiliation](#affiliation) | |
 | `CAST` | 5.0 | [Caste](#caste) | |
 | \*     | 5.0 | [Childless](#childless) | encoded as `NCH 0` |
-| `NATI` | 7.0 | [Clan](#clan) | one of several types of `NATI` |
+| `NATI` | 5.4 | [Clan](#clan) | one of several types of `NATI` |
 | \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
 | `EDUC` | 4.0 | Education | |
 | `NATI` | 5.4 | [Ethnicity](#ethnicity) | one of several types of `NATI` |

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -187,7 +187,7 @@ The most closely related structures are:
 Related proposals include
 
 - Ethnicity: ethnicities typically have some geographic association, but generally much larger and less fine-grained than a heimat
-- Nationality: generally broader than heimat in what region it covers
+- Nationality: a nation is often a larger region than a heimat, and a person can have a nationality without being geographically from that nation's region
 - Tribe: members of a tribe may share a heimat, but tribes may be defined by other characteristics too
 - Clan: members of a clan may share a heimat, but clans may be defined by other characteristics too
 - Affiliation: a person with a given heimat needn't have any affiliation with others with the same heimat

--- a/attribute-event-requests/INDI-attribute.md
+++ b/attribute-event-requests/INDI-attribute.md
@@ -14,7 +14,7 @@ Guides for using this document can be found in the associated [README.md](README
 | \* | 3.0 | [Died Before Eight](#died-before-eight) | encoded as `DEAT`.`AGE <8y` |
 | `EDUC` | 4.0 | Education | |
 | `NATI` | 5.4 | [Ethnicity](#ethnicity) | one of several types of `NATI` |
-| `NATI` | 5.4 | [Heimat](#heimat) | one of several types of `NATI` |
+| | | [Heimat](#heimat) | |
 | `IDNO` | 5.3 | [Identifying Number](#identifying-number) | |
 | | | [Life Sketch](#life-sketch) | |
 | | | [Military Service](#military-service) | |


### PR DESCRIPTION
Update five terms that are subsumed by NATI:

- Clan
- Ethnicity
- Heimat
- Nationality
- Tribe

Note: I'm unsure of "Heimat" as it is not a term used in my native culture, but the references I could find online seemed to indicate it was subsumed by NATI.

See also the partially-related #314 which proposes changing the one-word title of the NATI structure type in the spec to better match its definition.