### PR TITLE
add permitted epochs to calender YAML

### DIFF
--- a/build/uri-def.py
+++ b/build/uri-def.py
@@ -115,7 +115,9 @@ def find_cat_tables(txt, g7, tagsets):
 def find_calendars(txt, g7):
     """Looks for sections defining a `g7:cal-` URI"""
     for bit in re.finditer(r'#+ `[^`]*`[^\n]*\n+((?:\n+(?!#)|[^\n])*is `g7:(cal-[^`]*)`(?:\n+(?!#)|[^\n#])*)', txt):
-        g7[bit.group(2)] = ('calendar',[bit.group(1)])
+        m = re.search('The epoch markers? ([`_A-Z0-9, and]+) (is|are) permitted', bit.group(1))
+        marker = [] if not m else re.findall(r'[A-Z0-9_]+', m[1])
+        g7[bit.group(2)] = ('calendar',[bit.group(1)], marker)
         
 
 def joint_card(c1,c2):
@@ -387,6 +389,12 @@ if __name__ == '__main__':
                 print('\nmonths:', file=fh)
                 for k in calendars['g7:'+tag]:
                     print('  - "'+expand_prefix(k, prefixes)+'"', file=fh)
+                if len(g7[tag][2]) == 0:
+                    print('\nepochs: []', file=fh)
+                else:
+                    print('\nepochs:', file=fh)
+                    for epoch in g7[tag][2]:
+                        print('  -', epoch, file=fh)
             elif g7[tag][0] == 'month':
                 print('\ncalendars:', file=fh)
                 for k in calendars['g7:'+tag]:

--- a/extracted-files/tags/cal-FRENCH_R
+++ b/extracted-files/tags/cal-FRENCH_R
@@ -52,4 +52,6 @@ months:
   - "https://gedcom.io/terms/v7/month-THER"
   - "https://gedcom.io/terms/v7/month-FRUC"
   - "https://gedcom.io/terms/v7/month-COMP"
+
+epochs: []
 ...

--- a/extracted-files/tags/cal-GREGORIAN
+++ b/extracted-files/tags/cal-GREGORIAN
@@ -50,4 +50,7 @@ months:
   - "https://gedcom.io/terms/v7/month-OCT"
   - "https://gedcom.io/terms/v7/month-NOV"
   - "https://gedcom.io/terms/v7/month-DEC"
+
+epochs:
+  - BCE
 ...

--- a/extracted-files/tags/cal-HEBREW
+++ b/extracted-files/tags/cal-HEBREW
@@ -74,4 +74,6 @@ months:
   - "https://gedcom.io/terms/v7/month-TMZ"
   - "https://gedcom.io/terms/v7/month-AAV"
   - "https://gedcom.io/terms/v7/month-ELL"
+
+epochs: []
 ...

--- a/extracted-files/tags/cal-JULIAN
+++ b/extracted-files/tags/cal-JULIAN
@@ -39,4 +39,7 @@ months:
   - "https://gedcom.io/terms/v7/month-OCT"
   - "https://gedcom.io/terms/v7/month-NOV"
   - "https://gedcom.io/terms/v7/month-DEC"
+
+epochs:
+  - BCE
 ...


### PR DESCRIPTION
I was working on a YAML-file-based validator and realized I was missing information about which calendars allowed which epochs. This PR adds that, extracting it from the specification text.

This is part of a 3-part PR set; the other two parts are

- https://github.com/FamilySearch/GEDCOM.io/pull/85 which documents it in <https://gedcom.io/terms/format>
- https://github.com/FamilySearch/GEDCOM-registries/pull/4 which includes epoch in the YAML validation specification file.