### PR TITLE
Extract labels into YAML

### DIFF
--- a/extracted-files/tags/ABBR
+++ b/extracted-files/tags/ABBR
@@ -13,6 +13,8 @@ specification:
   - A short name of a title, description, or name used for sorting, filing, and
     retrieving records.
 
+label: 'Abbreviation'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/ADDR
+++ b/extracted-files/tags/ADDR
@@ -36,6 +36,8 @@ specification:
     Duplicating information bloats files and introduces the potential for
     self-contradiction. ADR1, ADR2, and ADR3 should not be added to new files.
 
+label: 'Address'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/ADOP
+++ b/extracted-files/tags/ADOP
@@ -15,6 +15,8 @@ specification:
   - Creation of a legally approved child-parent relationship that does not
     exist biologically.
 
+label: 'Adoption'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/ADOP-FAMC
+++ b/extracted-files/tags/ADOP-FAMC
@@ -19,6 +19,8 @@ specification:
     performed the adoption; or by using a FAM where the adopting individual is
     the only HUSB/WIFE.
 
+label: 'Family child'
+
 payload: "@<https://gedcom.io/terms/v7/record-FAM>@"
 
 substructures:

--- a/extracted-files/tags/ADR1
+++ b/extracted-files/tags/ADR1
@@ -17,6 +17,8 @@ specification:
     
     ADR1 should not be added to new files; see ADDRESS_STRUCTURE for more.
 
+label: 'Address Line 1'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/ADR2
+++ b/extracted-files/tags/ADR2
@@ -17,6 +17,8 @@ specification:
     
     ADR2 should not be added to new files; see ADDRESS_STRUCTURE for more.
 
+label: 'Address Line 2'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/ADR3
+++ b/extracted-files/tags/ADR3
@@ -17,6 +17,8 @@ specification:
     
     ADR3 should not be added to new files; see ADDRESS_STRUCTURE for more.
 
+label: 'Address Line 3'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/AGE
+++ b/extracted-files/tags/AGE
@@ -13,6 +13,8 @@ specification:
   - The age of the individual at the time an event occurred, or the age listed
     in the document.
 
+label: 'Age at event'
+
 payload: https://gedcom.io/terms/v7/type-Age
 
 substructures:

--- a/extracted-files/tags/AGNC
+++ b/extracted-files/tags/AGNC
@@ -16,6 +16,8 @@ specification:
     or events, or an organization responsible for creating or archiving
     records.
 
+label: 'Responsible agency'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/ALIA
+++ b/extracted-files/tags/ALIA
@@ -22,6 +22,8 @@ specification:
     mutually linked by symmetric pairs of ALIA pointers. A future version of
     this specification may adjust the definition of ALIA.
 
+label: 'Alias'
+
 payload: "@<https://gedcom.io/terms/v7/record-INDI>@"
 
 substructures:

--- a/extracted-files/tags/ANCI
+++ b/extracted-files/tags/ANCI
@@ -13,6 +13,8 @@ specification:
   - Indicates an interest in additional research for ancestors of this
     individual. (See also DESI).
 
+label: 'Ancestor interest'
+
 payload: "@<https://gedcom.io/terms/v7/record-SUBM>@"
 
 substructures: {}

--- a/extracted-files/tags/ANUL
+++ b/extracted-files/tags/ANUL
@@ -14,6 +14,8 @@ specification:
   - annulment
   - Declaring a marriage void from the beginning (never existed).
 
+label: 'Annulment'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/ASSO
+++ b/extracted-files/tags/ASSO
@@ -31,6 +31,8 @@ specification:
         2 ASSO @I2@
         3 ROLE CLERGY
 
+label: 'Associates'
+
 payload: "@<https://gedcom.io/terms/v7/record-INDI>@"
 
 substructures:

--- a/extracted-files/tags/AUTH
+++ b/extracted-files/tags/AUTH
@@ -15,6 +15,8 @@ specification:
     an unpublished source, this may be an individual, a government agency,
     church organization, or private organization.
 
+label: 'Author'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/BAPL
+++ b/extracted-files/tags/BAPL
@@ -15,6 +15,8 @@ specification:
   - The event of baptism performed at age 8 or later by priesthood authority of
     The Church of Jesus Christ of Latter-day Saints. (See also BAPM)
 
+label: 'Baptism, Latter-Day Saint'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/BAPM
+++ b/extracted-files/tags/BAPM
@@ -14,6 +14,8 @@ specification:
   - baptism
   - Baptism, performed in infancy or later. (See also BAPL and CHR.)
 
+label: 'Baptism'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/BARM
+++ b/extracted-files/tags/BARM
@@ -14,6 +14,8 @@ specification:
   - Bar Mitzvah
   - The ceremonial event held when a Jewish boy reaches age 13.
 
+label: 'Bar Mitzvah'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/BASM
+++ b/extracted-files/tags/BASM
@@ -15,6 +15,8 @@ specification:
   - The ceremonial event held when a Jewish girl reaches age 13, also known as
     “Bat Mitzvah.”
 
+label: 'Bas Mitzvah'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/BIRT
+++ b/extracted-files/tags/BIRT
@@ -14,6 +14,8 @@ specification:
   - birth
   - Entering into life.
 
+label: 'Birth'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/BLES
+++ b/extracted-files/tags/BLES
@@ -15,6 +15,8 @@ specification:
   - Bestowing divine care or intercession. Sometimes given in connection with a
     naming ceremony.
 
+label: 'Blessing'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/BURI
+++ b/extracted-files/tags/BURI
@@ -14,6 +14,8 @@ specification:
   - burial
   - Disposing of the mortal remains of a deceased person.
 
+label: 'Burial'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/CALN
+++ b/extracted-files/tags/CALN
@@ -14,6 +14,8 @@ specification:
     from the holdings of a repository. Despite the word “number” in the name,
     may contain any character, not just digits.
 
+label: 'Call number'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/CAST
+++ b/extracted-files/tags/CAST
@@ -16,6 +16,8 @@ specification:
     based on racial or religious differences, or differences in wealth,
     inherited rank, profession, or occupation.
 
+label: 'Caste'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/CAUS
+++ b/extracted-files/tags/CAUS
@@ -14,6 +14,8 @@ specification:
     death event to show cause of death, such as might be listed on a death
     certificate.
 
+label: 'Cause'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/CHAN
+++ b/extracted-files/tags/CHAN
@@ -20,6 +20,8 @@ specification:
     recent, although only the most recent change is described by the DATE
     substructure.
 
+label: 'Change'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/CHIL
+++ b/extracted-files/tags/CHIL
@@ -13,6 +13,8 @@ specification:
   - The child in a family, whether biological, adopted, foster, sealed, or
     other relationship.
 
+label: 'Child'
+
 payload: "@<https://gedcom.io/terms/v7/record-INDI>@"
 
 substructures:

--- a/extracted-files/tags/CHR
+++ b/extracted-files/tags/CHR
@@ -14,6 +14,8 @@ specification:
   - christening
   - Baptism or naming events for a child.
 
+label: 'Christening'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/CHRA
+++ b/extracted-files/tags/CHRA
@@ -14,6 +14,8 @@ specification:
   - adult christening
   - Baptism or naming events for an adult person.
 
+label: 'Christening, adult'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/CITY
+++ b/extracted-files/tags/CITY
@@ -12,6 +12,8 @@ specification:
   - City
   - The name of the city used in the address. See ADDRESS_STRUCTURE for more.
 
+label: 'City'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/CONF
+++ b/extracted-files/tags/CONF
@@ -14,6 +14,8 @@ specification:
   - confirmation
   - Conferring full church membership.
 
+label: 'Confirmation'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/CONL
+++ b/extracted-files/tags/CONL
@@ -15,6 +15,8 @@ specification:
   - The religious event by which a person receives membership in The Church of
     Jesus Christ of Latter-day Saints. (See also CONF)
 
+label: 'Confirmation, Latter-Day Saint'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/CONT
+++ b/extracted-files/tags/CONT
@@ -14,6 +14,8 @@ specification:
     during serialization and is never present in parsed datasets. See Lines for
     more.
 
+label: 'Continued'
+
 payload: null
 
 substructures: {}

--- a/extracted-files/tags/COPR
+++ b/extracted-files/tags/COPR
@@ -13,6 +13,8 @@ specification:
   - A copyright statement, as appropriate for the copyright laws applicable to
     this data.
 
+label: 'Copyright'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/CORP
+++ b/extracted-files/tags/CORP
@@ -13,6 +13,8 @@ specification:
   - The name of the business, corporation, or person that produced or
     commissioned the product.
 
+label: 'Corporate name'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/CREA
+++ b/extracted-files/tags/CREA
@@ -16,6 +16,8 @@ specification:
     to the initial creation, it should not be modified after the structure is
     created.
 
+label: 'Creation'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/CREM
+++ b/extracted-files/tags/CREM
@@ -14,6 +14,8 @@ specification:
   - cremation
   - Disposal of the remains of a person’s body by fire.
 
+label: 'Cremation'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/CROP
+++ b/extracted-files/tags/CROP
@@ -33,6 +33,8 @@ specification:
     -   TOP or TOP + HEIGHT exceed the image height.
     -   CROP applied to a non-image or image without a defined pixel unit.
 
+label: 'Crop'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/CTRY
+++ b/extracted-files/tags/CTRY
@@ -13,6 +13,8 @@ specification:
   - The name of the country that pertains to the associated address. See
     ADDRESS_STRUCTURE for more.
 
+label: 'Country'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/DATA
+++ b/extracted-files/tags/DATA
@@ -15,6 +15,8 @@ specification:
     describe a source itself, while SOUR.DATA describes the content of the
     source.
 
+label: 'Data'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/DATA-EVEN
+++ b/extracted-files/tags/DATA-EVEN
@@ -16,6 +16,8 @@ specification:
     a comma and space. For example, a parish register of births, deaths, and
     marriages would be BIRT, DEAT, MARR.
 
+label: 'Event'
+
 payload: https://gedcom.io/terms/v7/type-List#Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-EVENATTR"

--- a/extracted-files/tags/DATA-EVEN-DATE
+++ b/extracted-files/tags/DATA-EVEN-DATE
@@ -13,6 +13,8 @@ specification:
   - The DatePeriod covered by the entire source; the period during which this
     source recorded events.
 
+label: 'Date'
+
 payload: https://gedcom.io/terms/v7/type-Date#period
 
 substructures:

--- a/extracted-files/tags/DATE
+++ b/extracted-files/tags/DATE
@@ -23,6 +23,8 @@ specification:
     There is currently no provision for approximate times or time phrases. Time
     phrases are expected to be added in version 7.1.
 
+label: 'Date'
+
 payload: https://gedcom.io/terms/v7/type-Date
 
 substructures:

--- a/extracted-files/tags/DATE-exact
+++ b/extracted-files/tags/DATE-exact
@@ -13,6 +13,8 @@ specification:
   - The principal date of the subject of the superstructure. The payload is a
     DateExact.
 
+label: 'Date'
+
 payload: https://gedcom.io/terms/v7/type-Date#exact
 
 substructures:

--- a/extracted-files/tags/DEAT
+++ b/extracted-files/tags/DEAT
@@ -14,6 +14,8 @@ specification:
   - death
   - Mortal life terminates.
 
+label: 'Death'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/DESI
+++ b/extracted-files/tags/DESI
@@ -13,6 +13,8 @@ specification:
   - Indicates an interest in research to identify additional descendants of
     this individual. See also ANCI.
 
+label: 'Descendant Interest'
+
 payload: "@<https://gedcom.io/terms/v7/record-SUBM>@"
 
 substructures: {}

--- a/extracted-files/tags/DEST
+++ b/extracted-files/tags/DEST
@@ -13,6 +13,8 @@ specification:
   - An identifier for the system expected to receive this document. See
     HEAD.SOUR for guidance on choosing identifiers.
 
+label: 'Destination'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/DIV
+++ b/extracted-files/tags/DIV
@@ -14,6 +14,8 @@ specification:
   - divorce
   - Dissolving a marriage through civil action.
 
+label: 'Divorce'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/DIVF
+++ b/extracted-files/tags/DIVF
@@ -14,6 +14,8 @@ specification:
   - divorce filed
   - Filing for a divorce by a spouse.
 
+label: 'Divorce filing'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/DSCR
+++ b/extracted-files/tags/DSCR
@@ -14,6 +14,8 @@ specification:
   - physical description
   - The physical characteristics of a person.
 
+label: 'Description'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/EDUC
+++ b/extracted-files/tags/EDUC
@@ -14,6 +14,8 @@ specification:
   - education
   - Indicator of a level of education attained.
 
+label: 'Education'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/EMAIL
+++ b/extracted-files/tags/EMAIL
@@ -21,6 +21,8 @@ specification:
     sometimes written EMAI and sometimes written EMAIL. EMAIL should be used in
     version 7.0 and later.
 
+label: 'Email'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/EMIG
+++ b/extracted-files/tags/EMIG
@@ -14,6 +14,8 @@ specification:
   - emigration
   - Leaving one’s homeland with the intent of residing elsewhere.
 
+label: 'Emigration'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/ENDL
+++ b/extracted-files/tags/ENDL
@@ -16,6 +16,8 @@ specification:
     performed by priesthood authority in a temple of The Church of Jesus Christ
     of Latter-day Saints.
 
+label: 'Endowment, Latter-Day Saint'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/ENGA
+++ b/extracted-files/tags/ENGA
@@ -14,6 +14,8 @@ specification:
   - engagement
   - Recording or announcing an agreement between 2 people to become married.
 
+label: 'Engagement'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/EXID
+++ b/extracted-files/tags/EXID
@@ -25,6 +25,8 @@ specification:
     EXID identifiers are expected to be unique. Once assigned, an EXID
     identifier should never be re-used for any other purpose.
 
+label: 'External Identifier'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/EXID-TYPE
+++ b/extracted-files/tags/EXID-TYPE
@@ -37,6 +37,8 @@ specification:
     
     Additional type URIs can be registered by filing a GitHub pull request.
 
+label: 'Type'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/FAM-CENS
+++ b/extracted-files/tags/FAM-CENS
@@ -15,6 +15,8 @@ specification:
   - Periodic count of the population for a designated locality, such as a
     national or state census.
 
+label: 'Census'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/FAM-EVEN
+++ b/extracted-files/tags/FAM-EVEN
@@ -12,6 +12,8 @@ specification:
   - Event
   - See https://gedcom.io/terms/v7/INDI-EVEN.
 
+label: 'Event'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/FAM-FACT
+++ b/extracted-files/tags/FAM-FACT
@@ -12,6 +12,8 @@ specification:
   - Fact
   - See https://gedcom.io/terms/v7/INDI-FACT.
 
+label: 'Fact'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/FAM-HUSB
+++ b/extracted-files/tags/FAM-HUSB
@@ -12,6 +12,8 @@ specification:
   - Husband
   - This is a partner in a FAM record. See FAMILY_RECORD for more.
 
+label: 'Husband'
+
 payload: "@<https://gedcom.io/terms/v7/record-INDI>@"
 
 substructures:

--- a/extracted-files/tags/FAM-NCHI
+++ b/extracted-files/tags/FAM-NCHI
@@ -14,6 +14,8 @@ specification:
   - number of children
   - The number of children that belong to this family.
 
+label: 'Number of children'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures:

--- a/extracted-files/tags/FAM-RESI
+++ b/extracted-files/tags/FAM-RESI
@@ -18,6 +18,8 @@ specification:
   - residence
   - An address or place of residence where a family resided.
 
+label: 'Residence'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/FAM-WIFE
+++ b/extracted-files/tags/FAM-WIFE
@@ -12,6 +12,8 @@ specification:
   - Wife
   - A partner in a FAM record. See FAMILY_RECORD for more.
 
+label: 'Wife'
+
 payload: "@<https://gedcom.io/terms/v7/record-INDI>@"
 
 substructures:

--- a/extracted-files/tags/FAMC
+++ b/extracted-files/tags/FAMC
@@ -12,6 +12,8 @@ specification:
   - Family child
   - The family with which this individual event is associated.
 
+label: 'Family child'
+
 payload: "@<https://gedcom.io/terms/v7/record-FAM>@"
 
 substructures: {}

--- a/extracted-files/tags/FAMC-ADOP
+++ b/extracted-files/tags/FAMC-ADOP
@@ -13,6 +13,8 @@ specification:
   - An enumerated value from set https://gedcom.io/terms/v7/enumset-ADOP
     indicating which parent(s) in the family adopted this individual.
 
+label: 'Adoption'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-ADOP"

--- a/extracted-files/tags/FAMC-STAT
+++ b/extracted-files/tags/FAMC-STAT
@@ -14,6 +14,8 @@ specification:
     assessing of the state or condition of a researcher’s belief in a family
     connection.
 
+label: 'Status'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-FAMC-STAT"

--- a/extracted-files/tags/FAMS
+++ b/extracted-files/tags/FAMS
@@ -12,6 +12,8 @@ specification:
   - Family spouse
   - The family in which an individual appears as a partner. See FAM for more.
 
+label: 'Family spouse'
+
 payload: "@<https://gedcom.io/terms/v7/record-FAM>@"
 
 substructures:

--- a/extracted-files/tags/FAX
+++ b/extracted-files/tags/FAX
@@ -13,6 +13,8 @@ specification:
   - A fax telephone number appropriate for sending data facsimiles. See PHON
     for more.
 
+label: 'Facsimile'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/FCOM
+++ b/extracted-files/tags/FCOM
@@ -14,6 +14,8 @@ specification:
   - first communion
   - The first act of sharing in the Lord’s supper as part of church worship.
 
+label: 'First communion'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/FILE
+++ b/extracted-files/tags/FILE
@@ -53,6 +53,8 @@ specification:
     defined by this version of the specification, but may be defined in a
     subsequent version.
 
+label: 'File reference'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/FILE-TRAN
+++ b/extracted-files/tags/FILE-TRAN
@@ -50,6 +50,8 @@ specification:
     every other TRAN substructure of its superstructure in either its language
     tag or its media type or both.
 
+label: 'Translation'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/FORM
+++ b/extracted-files/tags/FORM
@@ -12,6 +12,8 @@ specification:
   - Format
   - The media type of the file referenced by the superstructure.
 
+label: 'Format'
+
 payload: http://www.w3.org/ns/dcat#mediaType
 
 substructures:

--- a/extracted-files/tags/GEDC
+++ b/extracted-files/tags/GEDC
@@ -16,6 +16,8 @@ specification:
     It is recommended that applications write GEDC with its required subrecord
     VERS as the first substructure of HEAD.
 
+label: 'GEDCOM'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/GEDC-VERS
+++ b/extracted-files/tags/GEDC-VERS
@@ -15,6 +15,8 @@ specification:
     “7.0”); it may include the patch as well (for example, “7.0.1”), but doing
     so is not required. See [A Guide to Version Numbers] for more.
 
+label: 'Version'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/GIVN
+++ b/extracted-files/tags/GIVN
@@ -12,6 +12,8 @@ specification:
   - Given name
   - A given or earned name used for official identification of a person.
 
+label: 'Given name'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/GRAD
+++ b/extracted-files/tags/GRAD
@@ -14,6 +14,8 @@ specification:
   - graduation
   - Awarding educational diplomas or degrees to individuals.
 
+label: 'Graduation'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/HEAD
+++ b/extracted-files/tags/HEAD
@@ -25,6 +25,8 @@ specification:
             from.
     -   LANG and PLAC give a default value for the rest of the document.
 
+label: 'Header'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/HEAD-DATE
+++ b/extracted-files/tags/HEAD-DATE
@@ -12,6 +12,8 @@ specification:
   - Date
   - The DateExact that this document was created.
 
+label: 'Date'
+
 payload: https://gedcom.io/terms/v7/type-Date#exact
 
 substructures:

--- a/extracted-files/tags/HEAD-LANG
+++ b/extracted-files/tags/HEAD-LANG
@@ -31,6 +31,8 @@ specification:
     platform-specific places, such as the default language from operating
     system settings, user locales, Input Method Editors (IMEs), etc.
 
+label: 'Language'
+
 payload: http://www.w3.org/2001/XMLSchema#Language
 
 substructures: {}

--- a/extracted-files/tags/HEAD-PLAC
+++ b/extracted-files/tags/HEAD-PLAC
@@ -13,6 +13,8 @@ specification:
   - This is a placeholder for providing a default PLAC.FORM, and must not have
     a payload.
 
+label: 'Place'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/HEAD-PLAC-FORM
+++ b/extracted-files/tags/HEAD-PLAC-FORM
@@ -12,6 +12,8 @@ specification:
   - Format
   - Any PLAC with no FORM shall be treated as if it has this FORM.
 
+label: 'Format'
+
 payload: https://gedcom.io/terms/v7/type-List#Text
 
 substructures: {}

--- a/extracted-files/tags/HEAD-SOUR
+++ b/extracted-files/tags/HEAD-SOUR
@@ -15,6 +15,8 @@ specification:
     existing identifier is known, it should be used. Otherwise, a URI owned by
     the product should be used instead.
 
+label: 'Source'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/HEAD-SOUR-DATA
+++ b/extracted-files/tags/HEAD-SOUR-DATA
@@ -14,6 +14,8 @@ specification:
     was exported. The payload is the name of that source, with substructures
     providing additional details about the source (not the export).
 
+label: 'Data'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/HEIGHT
+++ b/extracted-files/tags/HEIGHT
@@ -19,6 +19,8 @@ specification:
         0 @I45@ INDI
         1 DSCR brown eyes, 5ft 10in, 198 pounds
 
+label: 'Height in pixels'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures: {}

--- a/extracted-files/tags/HUSB
+++ b/extracted-files/tags/HUSB
@@ -14,6 +14,8 @@ specification:
     specific to the individual described by the associated FAM’s HUSB
     substructure.
 
+label: 'Husband'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/IDNO
+++ b/extracted-files/tags/IDNO
@@ -16,6 +16,8 @@ specification:
     significant external system. It must have a TYPE substructure to define
     what kind of identification number is being provided.
 
+label: 'Identification number'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/IMMI
+++ b/extracted-files/tags/IMMI
@@ -14,6 +14,8 @@ specification:
   - immigration
   - Entering into a new locality with the intent of residing there.
 
+label: 'Immigration'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/INDI-CENS
+++ b/extracted-files/tags/INDI-CENS
@@ -15,6 +15,8 @@ specification:
   - Periodic count of the population for a designated locality, such as a
     national or state census.
 
+label: 'Census'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/INDI-EVEN
+++ b/extracted-files/tags/INDI-EVEN
@@ -27,6 +27,8 @@ specification:
         2 TYPE Equipment Lease
         2 DATE 4 NOV 1837
 
+label: 'Event'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/INDI-FACT
+++ b/extracted-files/tags/INDI-FACT
@@ -24,6 +24,8 @@ specification:
         1 FACT Woodworking
         2 TYPE Skills
 
+label: 'Fact'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/INDI-FAMC
+++ b/extracted-files/tags/INDI-FAMC
@@ -14,6 +14,8 @@ specification:
     a STAT substructure to show individuals who are not children of the family.
     See FAM and FAMC.STAT for more.
 
+label: 'Family child'
+
 payload: "@<https://gedcom.io/terms/v7/record-FAM>@"
 
 substructures:

--- a/extracted-files/tags/INDI-NAME
+++ b/extracted-files/tags/INDI-NAME
@@ -39,6 +39,8 @@ specification:
     Alternative approaches to representing names are being considered for
     future versions of this specification.
 
+label: 'Name'
+
 payload: https://gedcom.io/terms/v7/type-Name
 
 substructures:

--- a/extracted-files/tags/INDI-NCHI
+++ b/extracted-files/tags/INDI-NCHI
@@ -15,6 +15,8 @@ specification:
   - The number of children that this person is known to be the parent of (all
     marriages).
 
+label: 'Number of children'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures:

--- a/extracted-files/tags/INDI-RELI
+++ b/extracted-files/tags/INDI-RELI
@@ -12,6 +12,8 @@ specification:
   - Religion
   - An Individual Attribute. See also INDIVIDUAL_ATTRIBUTE_STRUCTURE.
 
+label: 'Religion'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/INDI-RESI
+++ b/extracted-files/tags/INDI-RESI
@@ -30,6 +30,8 @@ specification:
   - residence
   - An address or place of residence where an individual resided.
 
+label: 'Residence'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/INDI-TITL
+++ b/extracted-files/tags/INDI-TITL
@@ -12,6 +12,8 @@ specification:
   - Title
   - An Individual Attribute. See also INDIVIDUAL_ATTRIBUTE_STRUCTURE.
 
+label: 'Title'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/INIL
+++ b/extracted-files/tags/INIL
@@ -19,6 +19,8 @@ specification:
     performed by priesthood authority in a temple of The Church of Jesus Christ
     of Latter-day Saints.
 
+label: 'Initiatory, Latter-Day Saint'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/LANG
+++ b/extracted-files/tags/LANG
@@ -54,6 +54,8 @@ specification:
         3 PHRASE 2018年8月31日
         4 _LANG cmn
 
+label: 'Language'
+
 payload: http://www.w3.org/2001/XMLSchema#Language
 
 substructures: {}

--- a/extracted-files/tags/LATI
+++ b/extracted-files/tags/LATI
@@ -19,6 +19,8 @@ specification:
     18 degrees, 9 minutes, and 3.4 seconds North would be formatted as
     N18.150944.
 
+label: 'Latitude'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/LEFT
+++ b/extracted-files/tags/LEFT
@@ -13,6 +13,8 @@ specification:
   - Left is a number of pixels to not display from the left side of the image.
     See CROP for more.
 
+label: 'Left crop width'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures: {}

--- a/extracted-files/tags/LONG
+++ b/extracted-files/tags/LONG
@@ -19,6 +19,8 @@ specification:
     168 degrees, 9 minutes, and 3.4 seconds East would be formatted as
     E168.150944.
 
+label: 'Longitude'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/MAP
+++ b/extracted-files/tags/MAP
@@ -20,6 +20,8 @@ specification:
     “Belarus” may be anywhere within that nation’s 200,000 square kilometer
     area).
 
+label: 'Map'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/MARB
+++ b/extracted-files/tags/MARB
@@ -14,6 +14,8 @@ specification:
   - marriage bann
   - Official public notice given that 2 people intend to marry.
 
+label: 'Marriage banns'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/MARC
+++ b/extracted-files/tags/MARC
@@ -16,6 +16,8 @@ specification:
     agreement in which marriage partners reach agreement about the property
     rights of 1 or both, securing property to their children.
 
+label: 'Marriage contract'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/MARL
+++ b/extracted-files/tags/MARL
@@ -14,6 +14,8 @@ specification:
   - marriage license
   - Obtaining a legal license to marry.
 
+label: 'Marriage license'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/MARR
+++ b/extracted-files/tags/MARR
@@ -15,6 +15,8 @@ specification:
   - A legal, common-law, or customary event such as a wedding or marriage
     ceremony that joins 2 partners to create or extend a family unit.
 
+label: 'Marriage'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/MARS
+++ b/extracted-files/tags/MARS
@@ -16,6 +16,8 @@ specification:
     time they agree to release or modify property rights that would otherwise
     arise from the marriage.
 
+label: 'Marriage settlement'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/MEDI
+++ b/extracted-files/tags/MEDI
@@ -23,6 +23,8 @@ specification:
     compiled newspapers; for this asset, the CALN.MEDI is recommended to be
     ELECTRONIC rather than BOOK or NEWSPAPER.
 
+label: 'Medium'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-MEDI"

--- a/extracted-files/tags/MIME
+++ b/extracted-files/tags/MIME
@@ -57,6 +57,8 @@ specification:
     4.  Replace each &lt; with < and &gt; with >
     5.  Replace each &amp; with &
 
+label: 'Media type'
+
 payload: http://www.w3.org/ns/dcat#mediaType
 
 substructures: {}

--- a/extracted-files/tags/NAME
+++ b/extracted-files/tags/NAME
@@ -12,6 +12,8 @@ specification:
   - Name
   - The name of the superstructure’s subject, represented as a simple string.
 
+label: 'Name'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/NAME-TRAN
+++ b/extracted-files/tags/NAME-TRAN
@@ -42,6 +42,8 @@ specification:
     every other TRAN substructure of its superstructure in either its language
     tag or its media type or both.
 
+label: 'Translation'
+
 payload: https://gedcom.io/terms/v7/type-Name
 
 substructures:

--- a/extracted-files/tags/NAME-TYPE
+++ b/extracted-files/tags/NAME-TYPE
@@ -13,6 +13,8 @@ specification:
   - An enumerated value from set https://gedcom.io/terms/v7/enumset-NAME-TYPE
     indicating the type of the name.
 
+label: 'Type'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-NAME-TYPE"

--- a/extracted-files/tags/NATI
+++ b/extracted-files/tags/NATI
@@ -15,6 +15,8 @@ specification:
   - An individual’s national heritage or origin, or other folk, house, kindred,
     lineage, or tribal interest.
 
+label: 'Nationality'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/NATU
+++ b/extracted-files/tags/NATU
@@ -14,6 +14,8 @@ specification:
   - naturalization
   - Obtaining citizenship.
 
+label: 'Naturalization'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/NICK
+++ b/extracted-files/tags/NICK
@@ -13,6 +13,8 @@ specification:
   - A descriptive or familiar name that is used instead of, or in addition to,
     one’s proper name.
 
+label: 'Nickname'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/NMR
+++ b/extracted-files/tags/NMR
@@ -15,6 +15,8 @@ specification:
   - The number of times this person has participated in a family as a spouse or
     parent.
 
+label: 'Number of marriages'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures:

--- a/extracted-files/tags/NO
+++ b/extracted-files/tags/NO
@@ -29,6 +29,8 @@ specification:
     
     means “no marriage had occurred as of March 24^(th), 1880”
 
+label: 'Did not happen'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-EVEN"

--- a/extracted-files/tags/NO-DATE
+++ b/extracted-files/tags/NO-DATE
@@ -13,6 +13,8 @@ specification:
   - The DatePeriod during which the event did not occur or the attribute did
     not apply.
 
+label: 'Date'
+
 payload: https://gedcom.io/terms/v7/type-Date#period
 
 substructures:

--- a/extracted-files/tags/NOTE
+++ b/extracted-files/tags/NOTE
@@ -19,6 +19,8 @@ specification:
     receiving the data knows what genealogical information the document
     contains.
 
+label: 'Note'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/NOTE-TRAN
+++ b/extracted-files/tags/NOTE-TRAN
@@ -53,6 +53,8 @@ specification:
     every other TRAN substructure of its superstructure in either its language
     tag or its media type or both.
 
+label: 'Translation'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/NPFX
+++ b/extracted-files/tags/NPFX
@@ -13,6 +13,8 @@ specification:
   - Text that appears on a name line before the given and surname parts of a
     name.
 
+label: 'Name prefix'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/NSFX
+++ b/extracted-files/tags/NSFX
@@ -13,6 +13,8 @@ specification:
   - Text which appears on a name line after or behind the given and surname
     parts of a name.
 
+label: 'Name suffix'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/OBJE
+++ b/extracted-files/tags/OBJE
@@ -20,6 +20,8 @@ specification:
     The optional TITL substructure supersedes any OBJE.FILE.TITL substructures
     included in the MULTIMEDIA_RECORD.
 
+label: 'Object'
+
 payload: "@<https://gedcom.io/terms/v7/record-OBJE>@"
 
 substructures:

--- a/extracted-files/tags/OCCU
+++ b/extracted-files/tags/OCCU
@@ -14,6 +14,8 @@ specification:
   - occupation
   - The type of work or profession of an individual.
 
+label: 'Occupation'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/ORDN
+++ b/extracted-files/tags/ORDN
@@ -14,6 +14,8 @@ specification:
   - ordination
   - Receiving authority to act in religious matters.
 
+label: 'Ordination'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/PAGE
+++ b/extracted-files/tags/PAGE
@@ -33,6 +33,8 @@ specification:
         2 SOUR @VOID@
         3 PAGE His grand-daughter Lydia told me this in 1980
 
+label: 'Page'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/PEDI
+++ b/extracted-files/tags/PEDI
@@ -14,6 +14,8 @@ specification:
     indicating the type of child-to-family relationship represented by the
     superstructure.
 
+label: 'Pedigree'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-PEDI"

--- a/extracted-files/tags/PHON
+++ b/extracted-files/tags/PHON
@@ -21,6 +21,8 @@ specification:
     
     See ITU standards E.123 and E.164 for more information.
 
+label: 'Phone'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/PHRASE
+++ b/extracted-files/tags/PHRASE
@@ -51,6 +51,8 @@ specification:
         2 TYPE OTHER
         3 PHRASE given by orphanage
 
+label: 'Phrase'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/PLAC
+++ b/extracted-files/tags/PLAC
@@ -53,6 +53,8 @@ specification:
     comma. An alternative system for representing locations is likely to be
     added in a later version.
 
+label: 'Place'
+
 payload: https://gedcom.io/terms/v7/type-List#Text
 
 substructures:

--- a/extracted-files/tags/PLAC-FORM
+++ b/extracted-files/tags/PLAC-FORM
@@ -20,6 +20,8 @@ specification:
         2 PLAC Baltimore, , Maryland, USA
         3 FORM City, County, State, Country
 
+label: 'Format'
+
 payload: https://gedcom.io/terms/v7/type-List#Text
 
 substructures: {}

--- a/extracted-files/tags/PLAC-TRAN
+++ b/extracted-files/tags/PLAC-TRAN
@@ -43,6 +43,8 @@ specification:
     every other TRAN substructure of its superstructure in either its language
     tag or its media type or both.
 
+label: 'Translation'
+
 payload: https://gedcom.io/terms/v7/type-List#Text
 
 substructures:

--- a/extracted-files/tags/POST
+++ b/extracted-files/tags/POST
@@ -13,6 +13,8 @@ specification:
   - A code used by a postal service to identify an area to facilitate mail
     handling. See ADDRESS_STRUCTURE for more.
 
+label: 'Postal code'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/PROB
+++ b/extracted-files/tags/PROB
@@ -15,6 +15,8 @@ specification:
   - Judicial determination of the validity of a will. It may indicate several
     related court activities over several dates.
 
+label: 'Probate'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/PROP
+++ b/extracted-files/tags/PROP
@@ -15,6 +15,8 @@ specification:
   - Pertaining to possessions such as real estate or other property of
     interest.
 
+label: 'Property'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/PUBL
+++ b/extracted-files/tags/PUBL
@@ -20,6 +20,8 @@ specification:
     of a person making a declaration for a pension or the city and state of
     residence of the writer of a letter.
 
+label: 'Publication'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/QUAY
+++ b/extracted-files/tags/QUAY
@@ -17,6 +17,8 @@ specification:
     not intended to eliminate the receivers’ need to evaluate the evidence for
     themselves.
 
+label: 'Quality of data'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-QUAY"

--- a/extracted-files/tags/REFN
+++ b/extracted-files/tags/REFN
@@ -20,6 +20,8 @@ specification:
     Multiple structures describing different aspects of the same subject must
     not have the same REFN value.
 
+label: 'Reference'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/RELI
+++ b/extracted-files/tags/RELI
@@ -16,6 +16,8 @@ specification:
   - A religious denomination to which a person is affiliated or for which a
     record applies.
 
+label: 'Religion'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/REPO
+++ b/extracted-files/tags/REPO
@@ -18,6 +18,8 @@ specification:
     number of the source at that repository. The call number of that source
     should be recorded using a CALN substructure.
 
+label: 'Repository'
+
 payload: "@<https://gedcom.io/terms/v7/record-REPO>@"
 
 substructures:

--- a/extracted-files/tags/RESN
+++ b/extracted-files/tags/RESN
@@ -24,6 +24,8 @@ specification:
     
     This is metadata about the structure itself, not data about its subject.
 
+label: 'Restriction'
+
 payload: https://gedcom.io/terms/v7/type-List#Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-RESN"

--- a/extracted-files/tags/RETI
+++ b/extracted-files/tags/RETI
@@ -15,6 +15,8 @@ specification:
   - Exiting an occupational relationship with an employer after a qualifying
     time period.
 
+label: 'Retirement'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/ROLE
+++ b/extracted-files/tags/ROLE
@@ -34,6 +34,8 @@ specification:
         2 ASSO @I3@
         3 ROLE WITN
 
+label: 'Role'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-ROLE"

--- a/extracted-files/tags/SCHMA
+++ b/extracted-files/tags/SCHMA
@@ -13,6 +13,8 @@ specification:
   - A container for storing meta-information about the extension tags used in
     this document. See Extensions for more.
 
+label: 'Extension schema'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/SDATE
+++ b/extracted-files/tags/SDATE
@@ -28,6 +28,8 @@ specification:
     different applications sort dates the same way, as the relative ordering of
     dates with different levels of precision is not well defined.
 
+label: 'Sort date'
+
 payload: https://gedcom.io/terms/v7/type-Date
 
 substructures:

--- a/extracted-files/tags/SEX
+++ b/extracted-files/tags/SEX
@@ -13,6 +13,8 @@ specification:
   - An enumerated value from set https://gedcom.io/terms/v7/enumset-SEX that
     indicates the sex of the individual at birth.
 
+label: 'Sex'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-SEX"

--- a/extracted-files/tags/SLGC
+++ b/extracted-files/tags/SLGC
@@ -16,6 +16,8 @@ specification:
     parents in a temple ceremony of The Church of Jesus Christ of Latter-day
     Saints.
 
+label: 'Sealing, child'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/SLGS
+++ b/extracted-files/tags/SLGS
@@ -18,6 +18,8 @@ specification:
     temple ceremony of The Church of Jesus Christ of Latter-day Saints. (See
     also MARR)
 
+label: 'Sealing, spouse'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/SNOTE
+++ b/extracted-files/tags/SNOTE
@@ -13,6 +13,8 @@ specification:
   - A pointer to a note that is shared by multiple structures. See
     NOTE_STRUCTURE for more.
 
+label: 'Shared note'
+
 payload: "@<https://gedcom.io/terms/v7/record-SNOTE>@"
 
 substructures: {}

--- a/extracted-files/tags/SOUR
+++ b/extracted-files/tags/SOUR
@@ -36,6 +36,8 @@ specification:
     Because each dataset is finite, this nesting is also guaranteed to be
     finite.
 
+label: 'Source'
+
 payload: "@<https://gedcom.io/terms/v7/record-SOUR>@"
 
 substructures:

--- a/extracted-files/tags/SOUR-DATA
+++ b/extracted-files/tags/SOUR-DATA
@@ -12,6 +12,8 @@ specification:
   - Data
   - See https://gedcom.io/terms/v7/DATA.
 
+label: 'Data'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/SOUR-EVEN
+++ b/extracted-files/tags/SOUR-EVEN
@@ -17,6 +17,8 @@ specification:
     assertions made from that record, such as the mother’s name or mother’s
     birth date.
 
+label: 'Event'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-EVENATTR"

--- a/extracted-files/tags/SPFX
+++ b/extracted-files/tags/SPFX
@@ -12,6 +12,8 @@ specification:
   - Surname prefix
   - A name piece used as a non-indexing pre-part of a surname.
 
+label: 'Surname prefix'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/SSN
+++ b/extracted-files/tags/SSN
@@ -15,6 +15,8 @@ specification:
   - A number assigned by the United States Social Security Administration, used
     for tax identification purposes. It is a type of IDNO.
 
+label: 'Social security number'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/STAE
+++ b/extracted-files/tags/STAE
@@ -13,6 +13,8 @@ specification:
   - A geographical division of a larger jurisdictional area, such as a state
     within the United States of America. See ADDRESS_STRUCTURE for more.
 
+label: 'State'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/SUBM
+++ b/extracted-files/tags/SUBM
@@ -13,6 +13,8 @@ specification:
   - A contributor of information in the substructure. This is metadata about
     the structure itself, not data about its subject.
 
+label: 'Submitter'
+
 payload: "@<https://gedcom.io/terms/v7/record-SUBM>@"
 
 substructures: {}

--- a/extracted-files/tags/SUBM-LANG
+++ b/extracted-files/tags/SUBM-LANG
@@ -15,6 +15,8 @@ specification:
     
     The payload of the LANG structure is a language tag, as defined by BCP 47.
 
+label: 'Language'
+
 payload: http://www.w3.org/2001/XMLSchema#Language
 
 substructures: {}

--- a/extracted-files/tags/SURN
+++ b/extracted-files/tags/SURN
@@ -12,6 +12,8 @@ specification:
   - Surname
   - A family name passed on or used by members of a family.
 
+label: 'Surname'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/TAG
+++ b/extracted-files/tags/TAG
@@ -13,6 +13,8 @@ specification:
   - Information relating to a single extension tag as used in this document.
     See Extensions for more.
 
+label: 'Extension tag'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/TEMP
+++ b/extracted-files/tags/TEMP
@@ -15,6 +15,8 @@ specification:
     names, but the list of abbreviations is no longer published by the Church
     and using abbreviations is no longer recommended.
 
+label: 'Temple'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/TEXT
+++ b/extracted-files/tags/TEXT
@@ -16,6 +16,8 @@ specification:
     evidence point of view, “what the original record keeper said” as opposed
     to the researcher’s interpretation.
 
+label: 'Text from Source'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/TIME
+++ b/extracted-files/tags/TIME
@@ -12,6 +12,8 @@ specification:
   - Time
   - A Time value in a 24-hour clock format.
 
+label: 'Time'
+
 payload: https://gedcom.io/terms/v7/type-Time
 
 substructures: {}

--- a/extracted-files/tags/TITL
+++ b/extracted-files/tags/TITL
@@ -37,6 +37,8 @@ specification:
   - A formal designation used by an individual in connection with positions of
     royalty or other social status, such as Grand Duke.
 
+label: 'Title'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/TOP
+++ b/extracted-files/tags/TOP
@@ -13,6 +13,8 @@ specification:
   - A number of pixels to not display from the top side of the image. See CROP
     for more.
 
+label: 'Top crop width'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures: {}

--- a/extracted-files/tags/TRLR
+++ b/extracted-files/tags/TRLR
@@ -13,6 +13,8 @@ specification:
   - A pseudo-structure marking the end of a dataset. See The Header and Trailer
     for more.
 
+label: 'Trailer'
+
 payload: null
 
 substructures: {}

--- a/extracted-files/tags/TYPE
+++ b/extracted-files/tags/TYPE
@@ -43,6 +43,8 @@ specification:
     
     See also FACT and EVEN for additional examples.
 
+label: 'Type'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/UID
+++ b/extracted-files/tags/UID
@@ -39,6 +39,8 @@ specification:
     input is expected and an appropriate action to take in case of an error is
     known.
 
+label: 'Unique Identifier'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/VERS
+++ b/extracted-files/tags/VERS
@@ -13,6 +13,8 @@ specification:
   - An identifier that represents the version level assigned to the associated
     product. It is defined and changed by the creators of the product.
 
+label: 'Version'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/WIDTH
+++ b/extracted-files/tags/WIDTH
@@ -12,6 +12,8 @@ specification:
   - Width in pixels
   - How many pixels to display horizontally for the image. See CROP for more.
 
+label: 'Width in pixels'
+
 payload: http://www.w3.org/2001/XMLSchema#nonNegativeInteger
 
 substructures: {}

--- a/extracted-files/tags/WIFE
+++ b/extracted-files/tags/WIFE
@@ -14,6 +14,8 @@ specification:
     specific to the individual described by the associated FAM’s WIFE
     substructure.
 
+label: 'Wife'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/WILL
+++ b/extracted-files/tags/WILL
@@ -16,6 +16,8 @@ specification:
     her estate. It takes effect after death. The event date is the date the
     will was signed while the person was alive. (See also PROB)
 
+label: 'Will'
+
 payload: Y|<NULL>
 
 substructures:

--- a/extracted-files/tags/WWW
+++ b/extracted-files/tags/WWW
@@ -17,6 +17,8 @@ specification:
     If an invalid or no longer existing web address is present upon import, it
     should be preserved as-is on export.
 
+label: 'Web address'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures: {}

--- a/extracted-files/tags/cal-FRENCH_R
+++ b/extracted-files/tags/cal-FRENCH_R
@@ -38,6 +38,8 @@ specification:
     
     The URI for this calendar is https://gedcom.io/terms/v7/cal-FRENCH_R
 
+label: 'French Republican'
+
 months:
   - "https://gedcom.io/terms/v7/month-VEND"
   - "https://gedcom.io/terms/v7/month-BRUM"

--- a/extracted-files/tags/cal-GREGORIAN
+++ b/extracted-files/tags/cal-GREGORIAN
@@ -37,6 +37,8 @@ specification:
     
     The URI for this calendar is https://gedcom.io/terms/v7/cal-GREGORIAN
 
+label: 'Gregorian'
+
 months:
   - "https://gedcom.io/terms/v7/month-JAN"
   - "https://gedcom.io/terms/v7/month-FEB"

--- a/extracted-files/tags/cal-HEBREW
+++ b/extracted-files/tags/cal-HEBREW
@@ -60,6 +60,8 @@ specification:
     
     The URI for this calendar is https://gedcom.io/terms/v7/cal-HEBREW
 
+label: 'Hebrew'
+
 months:
   - "https://gedcom.io/terms/v7/month-TSH"
   - "https://gedcom.io/terms/v7/month-CSH"

--- a/extracted-files/tags/cal-JULIAN
+++ b/extracted-files/tags/cal-JULIAN
@@ -26,6 +26,8 @@ specification:
     
     The URI for this calendar is https://gedcom.io/terms/v7/cal-JULIAN
 
+label: 'Julian'
+
 months:
   - "https://gedcom.io/terms/v7/month-JAN"
   - "https://gedcom.io/terms/v7/month-FEB"

--- a/extracted-files/tags/month-AAV
+++ b/extracted-files/tags/month-AAV
@@ -11,6 +11,8 @@ standard tag: AAV
 specification:
   - Av (אָב)
 
+label: 'Av'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-ADR
+++ b/extracted-files/tags/month-ADR
@@ -11,6 +11,8 @@ standard tag: ADR
 specification:
   - Adar I, Adar Rishon, First Adar, or Adar Aleph (אדר א׳)
 
+label: 'Adar I'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-ADS
+++ b/extracted-files/tags/month-ADS
@@ -11,6 +11,8 @@ standard tag: ADS
 specification:
   - Adar (אֲדָר); or Adar II, Adar Sheni, Second Adar, or Adar Bet (אדר ב׳)
 
+label: 'Adar'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-APR
+++ b/extracted-files/tags/month-APR
@@ -11,6 +11,8 @@ standard tag: APR
 specification:
   - April
 
+label: 'April'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-AUG
+++ b/extracted-files/tags/month-AUG
@@ -11,6 +11,8 @@ standard tag: AUG
 specification:
   - August
 
+label: 'August'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-BRUM
+++ b/extracted-files/tags/month-BRUM
@@ -11,6 +11,8 @@ standard tag: BRUM
 specification:
   - Brumaire
 
+label: 'Brumaire'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-COMP
+++ b/extracted-files/tags/month-COMP
@@ -11,6 +11,8 @@ standard tag: COMP
 specification:
   - Jour Complémentaires
 
+label: 'Jour Complémentaires'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-CSH
+++ b/extracted-files/tags/month-CSH
@@ -11,6 +11,8 @@ standard tag: CSH
 specification:
   - Marcheshvan (מַרְחֶשְׁוָן) or Cheshvan (חֶשְׁוָן)
 
+label: 'Marcheshvan'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-DEC
+++ b/extracted-files/tags/month-DEC
@@ -11,6 +11,8 @@ standard tag: DEC
 specification:
   - December
 
+label: 'December'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-ELL
+++ b/extracted-files/tags/month-ELL
@@ -11,6 +11,8 @@ standard tag: ELL
 specification:
   - Elul (אֱלוּל)
 
+label: 'Elul'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-FEB
+++ b/extracted-files/tags/month-FEB
@@ -11,6 +11,8 @@ standard tag: FEB
 specification:
   - February
 
+label: 'February'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-FLOR
+++ b/extracted-files/tags/month-FLOR
@@ -11,6 +11,8 @@ standard tag: FLOR
 specification:
   - Floréal
 
+label: 'Floréal'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-FRIM
+++ b/extracted-files/tags/month-FRIM
@@ -11,6 +11,8 @@ standard tag: FRIM
 specification:
   - Frimaire
 
+label: 'Frimaire'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-FRUC
+++ b/extracted-files/tags/month-FRUC
@@ -11,6 +11,8 @@ standard tag: FRUC
 specification:
   - Fructidor
 
+label: 'Fructidor'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-GERM
+++ b/extracted-files/tags/month-GERM
@@ -11,6 +11,8 @@ standard tag: GERM
 specification:
   - Germinal
 
+label: 'Germinal'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-IYR
+++ b/extracted-files/tags/month-IYR
@@ -11,6 +11,8 @@ standard tag: IYR
 specification:
   - Iyar (אִייָר)
 
+label: 'Iyar'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-JAN
+++ b/extracted-files/tags/month-JAN
@@ -11,6 +11,8 @@ standard tag: JAN
 specification:
   - January
 
+label: 'January'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-JUL
+++ b/extracted-files/tags/month-JUL
@@ -11,6 +11,8 @@ standard tag: JUL
 specification:
   - July
 
+label: 'July'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-JUN
+++ b/extracted-files/tags/month-JUN
@@ -11,6 +11,8 @@ standard tag: JUN
 specification:
   - June
 
+label: 'June'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-KSL
+++ b/extracted-files/tags/month-KSL
@@ -11,6 +11,8 @@ standard tag: KSL
 specification:
   - Kislev (כִּסְלֵו)
 
+label: 'Kislev'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-MAR
+++ b/extracted-files/tags/month-MAR
@@ -11,6 +11,8 @@ standard tag: MAR
 specification:
   - March
 
+label: 'March'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-MAY
+++ b/extracted-files/tags/month-MAY
@@ -11,6 +11,8 @@ standard tag: MAY
 specification:
   - May
 
+label: 'May'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-MESS
+++ b/extracted-files/tags/month-MESS
@@ -11,6 +11,8 @@ standard tag: MESS
 specification:
   - Messidor
 
+label: 'Messidor'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-NIVO
+++ b/extracted-files/tags/month-NIVO
@@ -11,6 +11,8 @@ standard tag: NIVO
 specification:
   - Nivôse
 
+label: 'Nivôse'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-NOV
+++ b/extracted-files/tags/month-NOV
@@ -11,6 +11,8 @@ standard tag: NOV
 specification:
   - November
 
+label: 'November'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-NSN
+++ b/extracted-files/tags/month-NSN
@@ -11,6 +11,8 @@ standard tag: NSN
 specification:
   - Nisan (נִיסָן)
 
+label: 'Nisan'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-OCT
+++ b/extracted-files/tags/month-OCT
@@ -11,6 +11,8 @@ standard tag: OCT
 specification:
   - October
 
+label: 'October'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-PLUV
+++ b/extracted-files/tags/month-PLUV
@@ -11,6 +11,8 @@ standard tag: PLUV
 specification:
   - Pluviôse
 
+label: 'Pluviôse'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-PRAI
+++ b/extracted-files/tags/month-PRAI
@@ -11,6 +11,8 @@ standard tag: PRAI
 specification:
   - Prairial
 
+label: 'Prairial'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-SEP
+++ b/extracted-files/tags/month-SEP
@@ -11,6 +11,8 @@ standard tag: SEP
 specification:
   - September
 
+label: 'September'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"

--- a/extracted-files/tags/month-SHV
+++ b/extracted-files/tags/month-SHV
@@ -11,6 +11,8 @@ standard tag: SHV
 specification:
   - Shevat (שְׁבָט)
 
+label: 'Shevat'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-SVN
+++ b/extracted-files/tags/month-SVN
@@ -11,6 +11,8 @@ standard tag: SVN
 specification:
   - Sivan (סִיוָן)
 
+label: 'Sivan'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-THER
+++ b/extracted-files/tags/month-THER
@@ -11,6 +11,8 @@ standard tag: THER
 specification:
   - Thermidor
 
+label: 'Thermidor'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-TMZ
+++ b/extracted-files/tags/month-TMZ
@@ -11,6 +11,8 @@ standard tag: TMZ
 specification:
   - Tammuz (תַּמּוּז)
 
+label: 'Tammuz'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-TSH
+++ b/extracted-files/tags/month-TSH
@@ -11,6 +11,8 @@ standard tag: TSH
 specification:
   - Tishrei (תִּשְׁרֵי)
 
+label: 'Tishrei'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-TVT
+++ b/extracted-files/tags/month-TVT
@@ -11,6 +11,8 @@ standard tag: TVT
 specification:
   - Tevet (טֵבֵת)
 
+label: 'Tevet'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
 ...

--- a/extracted-files/tags/month-VEND
+++ b/extracted-files/tags/month-VEND
@@ -11,6 +11,8 @@ standard tag: VEND
 specification:
   - Vendémiaire
 
+label: 'Vendémiaire'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/month-VENT
+++ b/extracted-files/tags/month-VENT
@@ -11,6 +11,8 @@ standard tag: VENT
 specification:
   - Ventôse
 
+label: 'Ventôse'
+
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
 ...

--- a/extracted-files/tags/ord-STAT
+++ b/extracted-files/tags/ord-STAT
@@ -13,6 +13,8 @@ specification:
   - An enumerated value from set https://gedcom.io/terms/v7/enumset-ord-STAT
     assessing of the state or condition of an ordinance.
 
+label: 'Status'
+
 payload: https://gedcom.io/terms/v7/type-Enum
 
 enumeration set: "https://gedcom.io/terms/v7/enumset-ord-STAT"

--- a/extracted-files/tags/record-FAM
+++ b/extracted-files/tags/record-FAM
@@ -58,6 +58,8 @@ specification:
     to point to an INDI record, the INDI record must use a FAMC to point to the
     FAM record.
 
+label: 'Family record'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/record-INDI
+++ b/extracted-files/tags/record-INDI
@@ -46,6 +46,8 @@ specification:
     and so on. A subordinate FAMC pointer is allowed to refer to a family where
     the individual does not appear as a child.
 
+label: 'Individual'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/record-OBJE
+++ b/extracted-files/tags/record-OBJE
@@ -24,6 +24,8 @@ specification:
     The change and creation dates should be for the OBJE record itself, not the
     underlying files.
 
+label: 'Object'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/record-REPO
+++ b/extracted-files/tags/record-REPO
@@ -25,6 +25,8 @@ specification:
     recommended that the repository record store current contact information,
     if known.
 
+label: 'Repository'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/record-SNOTE
+++ b/extracted-files/tags/record-SNOTE
@@ -46,6 +46,8 @@ specification:
     form a cycle. Applications should also ensure they can handle invalid files
     with such cycles in a safe manner.
 
+label: 'Shared note'
+
 payload: http://www.w3.org/2001/XMLSchema#string
 
 substructures:

--- a/extracted-files/tags/record-SOUR
+++ b/extracted-files/tags/record-SOUR
@@ -26,6 +26,8 @@ specification:
     form a cycle. Applications should also ensure they can handle invalid files
     with such cycles in a safe manner.
 
+label: 'Source'
+
 payload: null
 
 substructures:

--- a/extracted-files/tags/record-SUBM
+++ b/extracted-files/tags/record-SUBM
@@ -18,6 +18,8 @@ specification:
     HEAD, unless a SUBM structure inside a specific record points at a
     different submitter record.
 
+label: 'Submitter'
+
 payload: null
 
 substructures:


### PR DESCRIPTION
Labels are extracted for structures, calendars, and months because those always have labels in the spec. Some enumerated values do too, but others have a non-label description instead so those are not extracted. Enumeration sets do not have labels in the spec. Data types do have names, but this commit does not extract them.