### PR TITLE
Fix wording of section describing GEDC

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -692,7 +692,7 @@ Any `PLAC` with no [`FORM`](#PLAC-FORM) shall be treated as if it has this [`FOR
 
 A container for information about the entire document.
 
-It is recommended that applications write `GEDC` with its required subrecord `VERS` as the first substructure of `HEAD`.
+It is recommended that applications write `GEDC` with its required substructure `g7:GEDC-VERS` as the first substructure of `HEAD`.
 
 #### `GIVN` (Given name) `g7:GIVN`
 


### PR DESCRIPTION
- Replace `VERS` with `g7:GEDC-VERS` so it links to the correct section
- Replace "subrecord" with "substructure"
Resolves #336