### PR TITLE
Clarify that FILE-TRAN has a FILE-like payload

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1505,7 +1505,8 @@ if the resulting text is different from the text created by the HTML-to-text con
 #### `TRAN` (Translation) `g7:FILE-TRAN`
 
 A type of `TRAN` for external media files.
-Each `g7:NOTE-TRAN` must have a `FORM` substructure.
+Each `g7:FILE-TRAN` must have a `FORM` substructure.
+`g7:FILE-TRAN` payloads follow the same rules as `g7:FILE` payloads.
 See also `FILE`.
 
 :::example

--- a/specification/gedcom-4-gedzip.md
+++ b/specification/gedcom-4-gedzip.md
@@ -11,7 +11,7 @@ Each GEDZIP file contains the following entries:
 
 - An entry with name `gedcom.ged` containing a data stream.
 
-- An entry for each *local file* `FILE` structure in `gedcom.ged`, with the same zip *file name* as the corresponding `FILE` payload.
+- An entry for each *local file* `FILE` and `FILE-TRAN` structure in `gedcom.ged`, with the same zip *file name* as the corresponding `FILE` payload.
     If there is a local file named `gedcom.ged`, it must be renamed to a new unused filename with the same extension prior to constructing the GEDZIP.
 
 All file names inside a GEDZIP are case-sensitive.
@@ -26,6 +26,6 @@ A few details about the zip archive format are useful to fully understand GEDZIP
 - An archive can contain 1 or more files.
 - Files within an archive can be added, removed, or updated individually without needing to re-process the rest of the archive. Libraries such as [libzip](https://libzip.org) allow applications to operate directly on the zip archive as if it were a normal directory tree.
 - What the zip specification calls a "file name" is actually a local path and may contain directories.
-- Directory separators are `/` internally and are converted to the appropriate form by the zip processing tool during zipping and unzipping. Because of this, unzipping a GEDZIP in any local directory results in all GEDZIP `FILE` references working as-is for the resulting `gedcom.ged` without the need for any additional processing.
+- Directory separators are `/` internally and are converted to the appropriate form by the zip processing tool during zipping and unzipping. Because of this, unzipping a GEDZIP in any local directory results in all GEDZIP `FILE` and `FILE-TRAN` references working as-is for the resulting `gedcom.ged` without the need for any additional processing.
 :::
 


### PR DESCRIPTION
One of two ways to resolve #362 (the other is #368).

- Document that FILE-TRAN payloads must follow the same formatting rules as FILE

- Document that GEDZIP must consider both FILE and FILE-TRAN, not just FILE

This makes minimal changes to the spec (and, like the other proposal, no changes to GEDCOM files). It requires applicatiosn to treat the payloads of these two structure types specially and does not support extensions adding additional file-path-payload structure types.