### PR TITLE
Change FILE and FILE-TRAN payloads from Special to FilePath

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -329,3 +329,35 @@ The URI for the generic data type subsuming all `Special` data types is `xsd:str
 Special = Text
 ```
 
+## File Path
+
+The file path data type describes where an digital file is located in a machine-readable way.
+Syntactically, the payload is a URI reference as defined by [RFC 3986](https://www.rfc-editor.org/info/rfc3986), or a valid URL string as defined by the [WHATWG URL specification](https://url.spec.whatwg.org/).
+That is, it can be an absolute or relative URL, optionally with a fragment string.
+
+Version 7.0 only supports the following URLs:
+
+- A URL with scheme `ftp`, `http`, or `https` refers to a **web-accessible file**.
+
+- A URL with scheme `file` refers to a **machine-local file** as defined by [RFC 8089](https://www.rfc-editor.org/info/rfc8089). Machine-local files must not be used in [FamilySearch GEDZIP](#gedzip) nor when sharing datasets on the web or with unknown parties, but may be used for close collaboration between parties with known similar file structures.
+
+- A URI reference with all of the following:
+    - no scheme
+    - not beginning with `/` (U+002F)
+    - not containing any path segments equal to `..` (U+002E U+002E)
+    - not containing a reverse solidus character (U+005C `\`) or `banned` character, either directly or in escaped form
+    - no query or fragment
+    
+    refers to a **local file**. If the dataset is part of a [GEDZIP file](#gedzip), the URL of the local file is a zip archive filename; otherwise, the URL of a local file is resolved with *base* equal to the directory containing the dataset.
+    
+    It is recommended that local files use the directory prefix `media/`, but doing so is not required.
+
+    For compatibility with [GEDZIP](#gedzip) and related formats, it is recommended that the following file paths not be used:
+    
+    - `gedcom.ged`
+    - `MANIFEST.MF`
+    - any URL beginning `META-INF/`
+
+Additional URLs may be supported in future versions of this specification.
+
+The URI for the `FilePath` data type is `g7:type-FilePath`.

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -303,12 +303,12 @@ does not appear as a child.
 ```gedstruct
 n @XREF:OBJE@ OBJE                         {1:1}  g7:record-OBJE
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
-  +1 FILE <Special>                        {1:M}  g7:FILE
+  +1 FILE <FilePath>                       {1:M}  g7:FILE
      +2 FORM <MediaType>                   {1:1}  g7:FORM
         +3 MEDI <Enum>                     {0:1}  g7:MEDI
            +4 PHRASE <Text>                {0:1}  g7:PHRASE
      +2 TITL <Text>                        {0:1}  g7:TITL
-     +2 TRAN <Special>                     {0:M}  g7:FILE-TRAN
+     +2 TRAN <FilePath>                    {0:M}  g7:FILE-TRAN
         +3 FORM <MediaType>                {1:1}  g7:FORM
   +1 <<IDENTIFIER_STRUCTURE>>              {0:M}
   +1 <<NOTE_STRUCTURE>>                    {0:M}

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -638,7 +638,7 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 #### `FILE` (File reference) `g7:FILE`
 
 A reference to an external file.
-See the [File Path datatype](#file-path) for more.
+See the [File Path datatype](#file-path) for more details.
 
 #### `FORM` (Format) `g7:FORM`
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -638,32 +638,7 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 #### `FILE` (File reference) `g7:FILE`
 
 A reference to an external file.
-Syntactically, the payload is a URI reference as defined by [RFC 3986](https://www.rfc-editor.org/info/rfc3986), or a valid URL string as defined by the [WHATWG URL specification](https://url.spec.whatwg.org/).
-That is, it can be an absolute or relative URL, optionally with a fragment string.
-However, only the following URL types are used:
-
-- A URL with scheme `ftp`, `http`, or `https` refers to a **web-accessible file**.
-
-- A URL with scheme `file` refers to a **machine-local file** as defined by [RFC 8089](https://www.rfc-editor.org/info/rfc8089). Machine-local files must not be used in [FamilySearch GEDZIP](#gedzip) nor when sharing datasets on the web or with unknown parties, but may be used for close collaboration between parties with known similar file structures.
-
-- A URI reference with all of the following:
-    - no scheme
-    - not beginning with `/` (U+002F)
-    - not containing any path segments equal to `..` (U+002E U+002E)
-    - not containing a reverse solidus character (U+005C `\`) or `banned` character, either directly or in escaped form
-    - no query or fragment
-    
-    refers to a **local file**. If the dataset is part of a [GEDZIP file](#gedzip), the URL of the local file is a zip archive filename; otherwise, the URL of a local file is resolved with *base* equal to the directory containing the dataset.
-    
-    It is recommended that local files use the directory prefix `media/`, but doing so is not required.
-
-    For compatibility with [GEDZIP](#gedzip) and related formats, it is recommended that the following `FILE` payloads not be used:
-    
-    - `gedcom.ged`
-    - `MANIFEST.MF`
-    - any URL beginning `META-INF/`
-
-The meaning of a `FILE` payload with any format not listed above is not defined by this version of the specification, but may be defined in a subsequent version.
+See the [File Path datatype](#file-path) for more.
 
 #### `FORM` (Format) `g7:FORM`
 
@@ -1506,7 +1481,7 @@ if the resulting text is different from the text created by the HTML-to-text con
 
 A type of `TRAN` for external media files.
 Each `g7:NOTE-TRAN` must have a `FORM` substructure.
-See also `FILE`.
+See also `FILE` and the [File Path datatype](#file-path).
 
 :::example
 If an mp3 audio file

--- a/specification/gedcom-4-gedzip.md
+++ b/specification/gedcom-4-gedzip.md
@@ -11,7 +11,7 @@ Each GEDZIP file contains the following entries:
 
 - An entry with name `gedcom.ged` containing a data stream.
 
-- An entry for each *local file* `FILE` structure in `gedcom.ged`, with the same zip *file name* as the corresponding `FILE` payload.
+- An entry for each *local file* `g7:datatype-FilePath` payload in `gedcom.ged`, with the same zip *file name* as the payload.
     If there is a local file named `gedcom.ged`, it must be renamed to a new unused filename with the same extension prior to constructing the GEDZIP.
 
 All file names inside a GEDZIP are case-sensitive.
@@ -26,6 +26,6 @@ A few details about the zip archive format are useful to fully understand GEDZIP
 - An archive can contain 1 or more files.
 - Files within an archive can be added, removed, or updated individually without needing to re-process the rest of the archive. Libraries such as [libzip](https://libzip.org) allow applications to operate directly on the zip archive as if it were a normal directory tree.
 - What the zip specification calls a "file name" is actually a local path and may contain directories.
-- Directory separators are `/` internally and are converted to the appropriate form by the zip processing tool during zipping and unzipping. Because of this, unzipping a GEDZIP in any local directory results in all GEDZIP `FILE` references working as-is for the resulting `gedcom.ged` without the need for any additional processing.
+- Directory separators are `/` internally and are converted to the appropriate form by the zip processing tool during zipping and unzipping. Because of this, unzipping a GEDZIP in any local directory results in all GEDZIP file paths working as-is for the resulting `gedcom.ged` without the need for any additional processing.
 :::
 


### PR DESCRIPTION
This adds a file path datatype, one of two options to resolve #362 (the other is #367). It adds a new datatype to the spec, but makes no change to the resulting GEDCOM files. The new datatype may make automated tooling and extensions with file paths easier to define.