### PR TITLE
Create a v7.1 URI prefix

### DIFF
--- a/specification/gedcom-0-introduction.md
+++ b/specification/gedcom-0-introduction.md
@@ -147,6 +147,7 @@ is shorthand for a URI beginning with the corresponding URI prefix
 | Short Prefix | URI Prefix                          |
 |:-------------|:------------------------------------|
 | `g7`         | `https://gedcom.io/terms/v7/`       |
+| `g7.1`       | `https://gedcom.io/terms/v7.1/`     |
 | `xsd`        | `http://www.w3.org/2001/XMLSchema#` |
 | `dcat`       | `http://www.w3.org/ns/dcat#`        |
 

--- a/specification/gedcom-1-hierarchical-container-format.md
+++ b/specification/gedcom-1-hierarchical-container-format.md
@@ -176,9 +176,9 @@ The tag `ADOP` is used in this document to represent two structure types.
 Which one is meant can be identified by the superstructure type as follows:
 
 | Superstructure type | Structure type identified by tag `ADOP` |
-|------------------|------------------|
-| `g7:record-INDI` | `g7:ADOP`        |
-| `g7:ADOP-FAMC`   | `g7:FAMC-ADOP`   |
+|---------------------|------------------|
+| `g7.1:record-INDI`  | `g7:ADOP`        |
+| `g7:ADOP-FAMC`      | `g7:FAMC-ADOP`   |
 
 An [extension-defined substructure](#extensions) could also be used to place either of these structure types in extension superstructures.
 

--- a/specification/gedcom-1-hierarchical-container-format.md
+++ b/specification/gedcom-1-hierarchical-container-format.md
@@ -177,12 +177,12 @@ Which one is meant can be identified by the superstructure type as follows:
 
 | Superstructure type | Structure type identified by tag `ADOP` |
 |---------------------|------------------|
-| `g7.1:record-INDI`  | `g7:ADOP`        |
+| `g7.1:record-INDI`  | `g7.1:ADOP`      |
 | `g7:ADOP-FAMC`      | `g7:FAMC-ADOP`   |
 
 An [extension-defined substructure](#extensions) could also be used to place either of these structure types in extension superstructures.
 
-The `ADOP` tag is also used in the set of enumerated values permitted by the `g7:DATA-EVEN`, `g7:SOUR-EVEN`, and `g7:NO` structure types.
+The `ADOP` tag is also used in the set of enumerated values permitted by the `g7:DATA-EVEN`, `g7:SOUR-EVEN`, and `g7.1:NO` structure types.
 :::
 
 The **line value** matches production `LineVal` and encodes the structure's payload.
@@ -373,8 +373,8 @@ Suppose `_DATE` is defined to mean a `g7:DATE` (using a [documented extension ta
 Because all substructures have meanings defined relative to their superstructures and no records do, standard records cannot be relocated and relocated standard structures cannot be used as records.
 
 :::example
-The `g7:PLAC` substructure documents where the event described in its superstructure occurred.
-If an application wants a record to describe the place itself it should create a new URI for that extension; reusing `g7:PLAC` for a record with no superstructure is not appropriate.
+The `g7.1:PLAC` substructure documents where the event described in its superstructure occurred.
+If an application wants a record to describe the place itself it should create a new URI for that extension; reusing `g7.1:PLAC` for a record with no superstructure is not appropriate.
 :::
 
 All other non-standard structures are prohibited. Examples of prohibited structures include, but are not limited to,

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -145,11 +145,11 @@ n HEAD                                     {1:1}  g7:HEAD
         +3 WWW <Special>                   {0:M}  g7:WWW
      +2 DATA <Text>                        {0:1}  g7:HEAD-SOUR-DATA
         +3 DATE <DateExact>                {0:1}  g7:DATE-exact
-           +4 TIME <Time>                  {0:1}  g7:TIME-exact
+           +4 TIME <Time>                  {0:1}  g7.1:TIME-exact
         +3 COPR <Text>                     {0:1}  g7:COPR
   +1 DEST <Special>                        {0:1}  g7:DEST
   +1 DATE <DateExact>                      {0:1}  g7:HEAD-DATE
-     +2 TIME <Time>                        {0:1}  g7:TIME-exact
+     +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
   +1 SUBM @<XREF:SUBM>@                    {0:1}  g7:SUBM
   +1 COPR <Text>                           {0:1}  g7:COPR
   +1 LANG <Language>                       {0:1}  g7:HEAD-LANG
@@ -175,7 +175,7 @@ A few substructures of note:
 #### `FAMILY_RECORD` :=
 
 ```gedstruct
-n @XREF:FAM@ FAM                           {1:1}  g7:record-FAM
+n @XREF:FAM@ FAM                           {1:1}  g7.1:record-FAM
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 <<FAMILY_ATTRIBUTE_STRUCTURE>>        {0:M}
   +1 <<FAMILY_EVENT_STRUCTURE>>            {0:M}
@@ -233,7 +233,7 @@ An `INDI` record may have multiple `FAMC` substructures pointing to the same `FA
 #### `INDIVIDUAL_RECORD` :=
 
 ```gedstruct
-n @XREF:INDI@ INDI                         {1:1}  g7:record-INDI
+n @XREF:INDI@ INDI                         {1:1}  g7.1:record-INDI
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 <<PERSONAL_NAME_STRUCTURE>>           {0:M}
   +1 SEX <Enum>                            {0:1}  g7.1:SEX
@@ -334,7 +334,7 @@ not the underlying files.
 #### `REPOSITORY_RECORD` :=
 
 ```gedstruct
-n @XREF:REPO@ REPO                         {1:1}  g7:record-REPO
+n @XREF:REPO@ REPO                         {1:1}  g7.1:record-REPO
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 NAME <Text>                           {1:1}  g7:NAME
   +1 <<ADDRESS_STRUCTURE>>                 {0:1}
@@ -360,7 +360,7 @@ Until such time, it is recommended that the repository record store current cont
 #### `SHARED_NOTE_RECORD` :=
 
 ```gedstruct
-n @XREF:SNOTE@ SNOTE <Text>                {1:1}  g7:record-SNOTE
+n @XREF:SNOTE@ SNOTE <Text>                {1:1}  g7.1:record-SNOTE
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 MIME <MediaType>                      {0:1}  g7:MIME
   +1 LANG <Language>                       {0:1}  g7:LANG
@@ -405,7 +405,7 @@ A `SHARED_NOTE_RECORD` may contain a pointer to a `SOURCE_RECORD` and vice versa
 #### `SOURCE_RECORD` :=
 
 ```gedstruct
-n @XREF:SOUR@ SOUR                         {1:1}  g7:record-SOUR
+n @XREF:SOUR@ SOUR                         {1:1}  g7.1:record-SOUR
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 DATA                                  {0:1}  g7:DATA
      +2 EVEN <List:Enum>                   {0:M}  g7:DATA-EVEN
@@ -447,7 +447,7 @@ A `SOURCE_RECORD` may contain a pointer to a `SHARED_NOTE_RECORD` and vice versa
 #### `SUBMITTER_RECORD` :=
 
 ```gedstruct
-n @XREF:SUBM@ SUBM                         {1:1}  g7:record-SUBM
+n @XREF:SUBM@ SUBM                         {1:1}  g7.1:record-SUBM
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 NAME <Text>                           {1:1}  g7:NAME
   +1 <<ADDRESS_STRUCTURE>>                 {0:1}
@@ -457,7 +457,7 @@ n @XREF:SUBM@ SUBM                         {1:1}  g7:record-SUBM
   +1 WWW <Special>                         {0:M}  g7:WWW
   +1 <<MULTIMEDIA_LINK>>                   {0:M}
   +1 LANG <Language>                       {0:M}  g7:SUBM-LANG
-  +1 ALIA @<XREF:INDI>@                    {0:1}  g7:SUBM-ALIA
+  +1 ALIA @<XREF:INDI>@                    {0:1}  g7.1:SUBM-ALIA
   +1 <<IDENTIFIER_STRUCTURE>>              {0:M}
   +1 <<NOTE_STRUCTURE>>                    {0:M}
   +1 <<CHANGE_DATE>>                       {0:1}
@@ -541,7 +541,7 @@ and that individual `@I2@` was the clergy officiating at their baptism.
 ```gedstruct
 n CHAN                                     {1:1}  g7:CHAN
   +1 DATE <DateExact>                      {1:1}  g7:DATE-exact
-     +2 TIME <Time>                        {0:1}  g7:TIME-exact
+     +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
   +1 <<NOTE_STRUCTURE>>                    {0:M}
 ```
 
@@ -554,7 +554,7 @@ The `NOTE` substructure may describe previous changes as well as the most recent
 ```gedstruct
 n CREA                                     {1:1}  g7:CREA
   +1 DATE <DateExact>                      {1:1}  g7:DATE-exact
-     +2 TIME <Time>                        {0:1}  g7:TIME-exact
+     +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
 ```
 
 The date of the initial creation of the superstructure.
@@ -593,7 +593,7 @@ n RELI <Text>                              {0:1}  g7:RELI
 n CAUS <Text>                              {0:1}  g7:CAUS
 n RESN <List:Enum>                         {0:1}  g7:RESN
 n SDATE <DateValue>                        {0:1}  g7:SDATE
-  +1 TIME <Time>                           {0:1}  g7:TIME
+  +1 TIME <Time>                           {0:1}  g7.1:TIME
      +2 PHRASE <Text>                      {0:1}  g7:PHRASE
   +1 PHRASE <Text>                         {0:1}  g7:PHRASE
 n <<ASSOCIATION_STRUCTURE>>                {0:M}
@@ -614,15 +614,15 @@ Conflicting event information should be represented by placing them in separate 
 
 ```gedstruct
 [
-n NCHI <Integer>                           {1:1}  g7:FAM-NCHI
+n NCHI <Integer>                           {1:1}  g7.1:FAM-NCHI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n RESI <Text>                              {1:1}  g7:FAM-RESI
+n RESI <Text>                              {1:1}  g7.1:FAM-RESI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n FACT <Text>                              {1:1}  g7:FAM-FACT
+n FACT <Text>                              {1:1}  g7.1:FAM-FACT
   +1 TYPE <Text>                           {1:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 ]
@@ -656,11 +656,11 @@ Substructures shared by most family events and attributes.
 
 ```` {.gedstruct .long}
 [
-n ANUL [Y|<NULL>]                          {1:1}  g7:ANUL
+n ANUL [Y|<NULL>]                          {1:1}  g7.1:ANUL
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n CENS [Y|<NULL>]                          {1:1}  g7:FAM-CENS
+n CENS [Y|<NULL>]                          {1:1}  g7.1:FAM-CENS
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
@@ -688,9 +688,9 @@ n MARL [Y|<NULL>]                          {1:1}  g7:MARL
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n MARR [Y|<NULL>]                          {1:1}  g7:MARR
+n MARR [Y|<NULL>]                          {1:1}  g7.1:MARR
   +1 TYPE <Text>                           {0:1}  g7:TYPE
-  +1 KIND <Enum>                           {0:1}  g7:MARR-KIND
+  +1 KIND <Enum>                           {0:1}  g7.1:MARR-KIND
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
 n MARS [Y|<NULL>]                          {1:1}  g7:MARS
@@ -860,9 +860,9 @@ n BLES [Y|<NULL>]                          {1:1}  g7:BLES
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n BURI [Y|<NULL>]                          {1:1}  g7:BURI
+n BURI [Y|<NULL>]                          {1:1}  g7.1:BURI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
-  +1 KIND <Enum>                           {0:1}  g7:BURI-KIND
+  +1 KIND <Enum>                           {0:1}  g7.1:BURI-KIND
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
 n CENS [Y|<NULL>]                          {1:1}  g7:INDI-CENS
@@ -980,7 +980,7 @@ n TEMP <Text>                            {0:1}  g7:TEMP
 n <<PLACE_STRUCTURE>>                    {0:1}
 n STAT <Enum>                            {0:1}  g7:ord-STAT
   +1 DATE <DateExact>                    {1:1}  g7:DATE-exact
-     +2 TIME <Time>                      {0:1}  g7:TIME-exact
+     +2 TIME <Time>                      {0:1}  g7.1:TIME-exact
 n <<NOTE_STRUCTURE>>                     {0:M}
 n <<SOURCE_CITATION>>                    {0:M}
 ```
@@ -1047,7 +1047,7 @@ means "no marriage had occurred as of March 24^th^, 1880"
 
 ```gedstruct
 [
-n NOTE <Text>                              {1:1}  g7:NOTE
+n NOTE <Text>                              {1:1}  g7.1:NOTE
   +1 MIME <MediaType>                      {0:1}  g7:MIME
   +1 LANG <Language>                       {0:1}  g7:LANG
   +1 TRAN <Text>                           {0:M}  g7:NOTE-TRAN
@@ -1104,9 +1104,9 @@ Even when multiple `SURN` tags are used, the `PersonalName` data type identifies
 #### `PERSONAL_NAME_STRUCTURE` :=
 
 ```gedstruct
-n NAME <PersonalName>                      {1:1}  g7:INDI-NAME
+n NAME <PersonalName>                      {1:1}  g7.1:INDI-NAME
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
-  +1 TYPE <Enum>                           {0:1}  g7:NAME-TYPE
+  +1 TYPE <Enum>                           {0:1}  g7.1:NAME-TYPE
      +2 PHRASE <Text>                      {0:1}  g7:PHRASE
   +1 <<PERSONAL_NAME_PIECES>>              {0:1}
   +1 LANG <Language>                       {0:1}  g7:LANG
@@ -1128,7 +1128,7 @@ It is recommended, but not required, that if the name pieces are used, the same 
 
 A `TYPE` is used to specify the particular variation that this name is.
 For example; it could indicate that this name is a name taken at immigration or that it could be an ‘also known as’ name.
-See `g7:enumset-NAME-TYPE` for more details.
+See `g7.1:enumset-NAME-TYPE` for more details.
 
 :::note
 Alternative approaches to representing names are being considered for future versions of this specification.
@@ -1191,7 +1191,7 @@ This specification does not support places where a region name contains a comma.
 #### `SOURCE_CITATION` :=
 
 ```gedstruct
-n SOUR @<XREF:SOUR>@                       {1:1}  g7:SOUR
+n SOUR @<XREF:SOUR>@                       {1:1}  g7.1:SOUR
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 <<SOURCE_CITATION>>                   {0:M}
   +1 PAGE <Text>                           {0:1}  g7:PAGE

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -54,7 +54,7 @@ The intent of this metasyntax is to resemble the line encoding of allowable stru
     and the `CREATION_DATE` rule begins
 
     ````gedstruct
-    n CREA                                     {1:1}  g7:CREA
+    n CREA                                     {1:1}  g7.1:CREA
     ````
     
     Thus, a `FAM` record has an optional singular `CREA` substructure
@@ -129,12 +129,12 @@ n <<SUBMITTER_RECORD>>                     {1:1}
 #### `HEADER` :=
 
 ```gedstruct
-n HEAD                                     {1:1}  g7:HEAD
+n HEAD                                     {1:1}  g7.1:HEAD
   +1 GEDC                                  {1:1}  g7:GEDC
      +2 VERS <Special>                     {1:1}  g7:GEDC-VERS
   +1 SCHMA                                 {0:1}  g7:SCHMA
      +2 TAG <Special>                      {0:M}  g7:TAG
-  +1 SOUR <Special>                        {0:1}  g7:HEAD-SOUR
+  +1 SOUR <Special>                        {0:1}  g7.1:HEAD-SOUR
      +2 VERS <Special>                     {0:1}  g7:VERS
      +2 NAME <Text>                        {0:1}  g7:NAME
      +2 CORP <Text>                        {0:1}  g7:CORP
@@ -143,12 +143,12 @@ n HEAD                                     {1:1}  g7:HEAD
         +3 EMAIL <Special>                 {0:M}  g7:EMAIL
         +3 FAX <Special>                   {0:M}  g7:FAX
         +3 WWW <Special>                   {0:M}  g7:WWW
-     +2 DATA <Text>                        {0:1}  g7:HEAD-SOUR-DATA
-        +3 DATE <DateExact>                {0:1}  g7:DATE-exact
+     +2 DATA <Text>                        {0:1}  g7.1:HEAD-SOUR-DATA
+        +3 DATE <DateExact>                {0:1}  g7.1:DATE-exact
            +4 TIME <Time>                  {0:1}  g7.1:TIME-exact
         +3 COPR <Text>                     {0:1}  g7:COPR
   +1 DEST <Special>                        {0:1}  g7:DEST
-  +1 DATE <DateExact>                      {0:1}  g7:HEAD-DATE
+  +1 DATE <DateExact>                      {0:1}  g7.1:HEAD-DATE
      +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
   +1 SUBM @<XREF:SUBM>@                    {0:1}  g7:SUBM
   +1 COPR <Text>                           {0:1}  g7:COPR
@@ -252,7 +252,7 @@ n @XREF:INDI@ INDI                         {1:1}  g7.1:record-INDI
      +2 <<NOTE_STRUCTURE>>                 {0:M}
      +2 EXID <Special>                     {0:M}  g7:EXID
         +3 TYPE <Special>                  {0:1}  g7:EXID-TYPE
-  +1 FAMS @<XREF:FAM>@                     {0:M}  g7:FAMS
+  +1 FAMS @<XREF:FAM>@                     {0:M}  g7.1:FAMS
      +2 <<NOTE_STRUCTURE>>                 {0:M}
   +1 SUBM @<XREF:SUBM>@                    {0:M}  g7:SUBM
   +1 <<ASSOCIATION_STRUCTURE>>             {0:M}
@@ -306,7 +306,7 @@ does not appear as a child.
 #### `MULTIMEDIA_RECORD` :=
 
 ```gedstruct
-n @XREF:OBJE@ OBJE                         {1:1}  g7:record-OBJE
+n @XREF:OBJE@ OBJE                         {1:1}  g7.1:record-OBJE
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 FILE <FilePath>                       {1:M}  g7:FILE
      +2 FORM <MediaType>                   {1:1}  g7:FORM
@@ -506,7 +506,7 @@ Duplicating information bloats files and introduces the potential for self-contr
 #### `ASSOCIATION_STRUCTURE` :=
 
 ```gedstruct
-n ASSO @<XREF:INDI>@                       {1:1}  g7:ASSO
+n ASSO @<XREF:INDI>@                       {1:1}  g7.1:ASSO
   +1 PHRASE <Text>                         {0:1}  g7:PHRASE
   +1 ROLE <Enum>                           {1:1}  g7:ROLE
      +2 PHRASE <Text>                      {0:1}  g7:PHRASE
@@ -539,8 +539,8 @@ and that individual `@I2@` was the clergy officiating at their baptism.
 #### `CHANGE_DATE` :=
 
 ```gedstruct
-n CHAN                                     {1:1}  g7:CHAN
-  +1 DATE <DateExact>                      {1:1}  g7:DATE-exact
+n CHAN                                     {1:1}  g7.1:CHAN
+  +1 DATE <DateExact>                      {1:1}  g7.1:DATE-exact
      +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
   +1 <<NOTE_STRUCTURE>>                    {0:M}
 ```
@@ -552,8 +552,8 @@ The `NOTE` substructure may describe previous changes as well as the most recent
 #### `CREATION_DATE` :=
 
 ```gedstruct
-n CREA                                     {1:1}  g7:CREA
-  +1 DATE <DateExact>                      {1:1}  g7:DATE-exact
+n CREA                                     {1:1}  g7.1:CREA
+  +1 DATE <DateExact>                      {1:1}  g7.1:DATE-exact
      +2 TIME <Time>                        {0:1}  g7.1:TIME-exact
 ```
 
@@ -592,7 +592,7 @@ n AGNC <Text>                              {0:1}  g7:AGNC
 n RELI <Text>                              {0:1}  g7:RELI
 n CAUS <Text>                              {0:1}  g7:CAUS
 n RESN <List:Enum>                         {0:1}  g7:RESN
-n SDATE <DateValue>                        {0:1}  g7:SDATE
+n SDATE <DateValue>                        {0:1}  g7.1:SDATE
   +1 TIME <Time>                           {0:1}  g7.1:TIME
      +2 PHRASE <Text>                      {0:1}  g7:PHRASE
   +1 PHRASE <Text>                         {0:1}  g7:PHRASE
@@ -664,27 +664,27 @@ n CENS [Y|<NULL>]                          {1:1}  g7.1:FAM-CENS
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n DIV [Y|<NULL>]                           {1:1}  g7:DIV
+n DIV [Y|<NULL>]                           {1:1}  g7.1:DIV
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n DIVF [Y|<NULL>]                          {1:1}  g7:DIVF
+n DIVF [Y|<NULL>]                          {1:1}  g7.1:DIVF
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n ENGA [Y|<NULL>]                          {1:1}  g7:ENGA
+n ENGA [Y|<NULL>]                          {1:1}  g7.1:ENGA
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n MARB [Y|<NULL>]                          {1:1}  g7:MARB
+n MARB [Y|<NULL>]                          {1:1}  g7.1:MARB
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n MARC [Y|<NULL>]                          {1:1}  g7:MARC
+n MARC [Y|<NULL>]                          {1:1}  g7.1:MARC
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n MARL [Y|<NULL>]                          {1:1}  g7:MARL
+n MARL [Y|<NULL>]                          {1:1}  g7.1:MARL
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
@@ -693,11 +693,11 @@ n MARR [Y|<NULL>]                          {1:1}  g7.1:MARR
   +1 KIND <Enum>                           {0:1}  g7.1:MARR-KIND
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n MARS [Y|<NULL>]                          {1:1}  g7:MARS
+n MARS [Y|<NULL>]                          {1:1}  g7.1:MARS
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 |
-n EVEN <Text>                              {1:1}  g7:FAM-EVEN
+n EVEN <Text>                              {1:1}  g7.1:FAM-EVEN
   +1 TYPE <Text>                           {1:1}  g7:TYPE
   +1 <<FAMILY_EVENT_DETAIL>>               {0:1}
 ]
@@ -751,59 +751,59 @@ and each is different in purpose:
 
 ```` {.gedstruct .long}
 [
-n CAST <Text>                              {1:1}  g7:CAST
+n CAST <Text>                              {1:1}  g7.1:CAST
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n DSCR <Text>                              {1:1}  g7:DSCR
+n DSCR <Text>                              {1:1}  g7.1:DSCR
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n EDUC <Text>                              {1:1}  g7:EDUC
+n EDUC <Text>                              {1:1}  g7.1:EDUC
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n IDNO <Special>                           {1:1}  g7:IDNO
+n IDNO <Special>                           {1:1}  g7.1:IDNO
   +1 TYPE <Text>                           {1:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n NATI <Text>                              {1:1}  g7:NATI
+n NATI <Text>                              {1:1}  g7.1:NATI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n NCHI <Integer>                           {1:1}  g7:INDI-NCHI
+n NCHI <Integer>                           {1:1}  g7.1:INDI-NCHI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n NMR <Integer>                            {1:1}  g7:NMR
+n NMR <Integer>                            {1:1}  g7.1:NMR
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n OCCU <Text>                              {1:1}  g7:OCCU
+n OCCU <Text>                              {1:1}  g7.1:OCCU
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n PROP <Text>                              {1:1}  g7:PROP
+n PROP <Text>                              {1:1}  g7.1:PROP
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n RELI <Text>                              {1:1}  g7:INDI-RELI
+n RELI <Text>                              {1:1}  g7.1:INDI-RELI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n RESI <Text>                              {1:1}  g7:INDI-RESI
+n RESI <Text>                              {1:1}  g7.1:INDI-RESI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n SSN <Special>                            {1:1}  g7:SSN
+n SSN <Special>                            {1:1}  g7.1:SSN
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n TITL <Text>                              {1:1}  g7:INDI-TITL
+n TITL <Text>                              {1:1}  g7.1:INDI-TITL
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n FACT <Text>                              {1:1}  g7:INDI-FACT
+n FACT <Text>                              {1:1}  g7.1:INDI-FACT
   +1 TYPE <Text>                           {1:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 ]
@@ -832,31 +832,31 @@ Substructures shared by most individual events and attributes.
 
 ```` {.gedstruct .long}
 [
-n ADOP [Y|<NULL>]                          {1:1}  g7:ADOP
+n ADOP [Y|<NULL>]                          {1:1}  g7.1:ADOP
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
   +1 FAMC @<XREF:FAM>@                     {0:1}  g7:ADOP-FAMC
      +2 ADOP <Enum>                        {0:1}  g7:FAMC-ADOP
         +3 PHRASE <Text>                   {0:1}  g7:PHRASE
 |
-n BAPM [Y|<NULL>]                          {1:1}  g7:BAPM
+n BAPM [Y|<NULL>]                          {1:1}  g7.1:BAPM
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n BARM [Y|<NULL>]                          {1:1}  g7:BARM
+n BARM [Y|<NULL>]                          {1:1}  g7.1:BARM
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n BASM [Y|<NULL>]                          {1:1}  g7:BASM
+n BASM [Y|<NULL>]                          {1:1}  g7.1:BASM
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n BIRT [Y|<NULL>]                          {1:1}  g7:BIRT
+n BIRT [Y|<NULL>]                          {1:1}  g7.1:BIRT
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
   +1 FAMC @<XREF:FAM>@                     {0:1}  g7:FAMC
 |
-n BLES [Y|<NULL>]                          {1:1}  g7:BLES
+n BLES [Y|<NULL>]                          {1:1}  g7.1:BLES
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
@@ -865,68 +865,68 @@ n BURI [Y|<NULL>]                          {1:1}  g7.1:BURI
   +1 KIND <Enum>                           {0:1}  g7.1:BURI-KIND
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n CENS [Y|<NULL>]                          {1:1}  g7:INDI-CENS
+n CENS [Y|<NULL>]                          {1:1}  g7.1:INDI-CENS
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n CHR [Y|<NULL>]                           {1:1}  g7:CHR
+n CHR [Y|<NULL>]                           {1:1}  g7.1:CHR
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
   +1 FAMC @<XREF:FAM>@                     {0:1}  g7:FAMC
 |
-n CHRA [Y|<NULL>]                          {1:1}  g7:CHRA
+n CHRA [Y|<NULL>]                          {1:1}  g7.1:CHRA
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n CONF [Y|<NULL>]                          {1:1}  g7:CONF
+n CONF [Y|<NULL>]                          {1:1}  g7.1:CONF
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n CREM [Y|<NULL>]                          {1:1}  g7:CREM
+n CREM [Y|<NULL>]                          {1:1}  g7.1:CREM
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n DEAT [Y|<NULL>]                          {1:1}  g7:DEAT
+n DEAT [Y|<NULL>]                          {1:1}  g7.1:DEAT
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n EMIG [Y|<NULL>]                          {1:1}  g7:EMIG
+n EMIG [Y|<NULL>]                          {1:1}  g7.1:EMIG
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n FCOM [Y|<NULL>]                          {1:1}  g7:FCOM
+n FCOM [Y|<NULL>]                          {1:1}  g7.1:FCOM
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n GRAD [Y|<NULL>]                          {1:1}  g7:GRAD
+n GRAD [Y|<NULL>]                          {1:1}  g7.1:GRAD
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n IMMI [Y|<NULL>]                          {1:1}  g7:IMMI
+n IMMI [Y|<NULL>]                          {1:1}  g7.1:IMMI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n NATU [Y|<NULL>]                          {1:1}  g7:NATU
+n NATU [Y|<NULL>]                          {1:1}  g7.1:NATU
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n ORDN [Y|<NULL>]                          {1:1}  g7:ORDN
+n ORDN [Y|<NULL>]                          {1:1}  g7.1:ORDN
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n PROB [Y|<NULL>]                          {1:1}  g7:PROB
+n PROB [Y|<NULL>]                          {1:1}  g7.1:PROB
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n RETI [Y|<NULL>]                          {1:1}  g7:RETI
+n RETI [Y|<NULL>]                          {1:1}  g7.1:RETI
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n WILL [Y|<NULL>]                          {1:1}  g7:WILL
+n WILL [Y|<NULL>]                          {1:1}  g7.1:WILL
   +1 TYPE <Text>                           {0:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 |
-n EVEN <Text>                              {1:1}  g7:INDI-EVEN
+n EVEN <Text>                              {1:1}  g7.1:INDI-EVEN
   +1 TYPE <Text>                           {1:1}  g7:TYPE
   +1 <<INDIVIDUAL_EVENT_DETAIL>>           {0:1}
 ]
@@ -952,19 +952,19 @@ Individual event structures vary as follows:
 
 ```gedstruct
 [
-n BAPL                                     {1:1}  g7:BAPL
+n BAPL                                     {1:1}  g7.1:BAPL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
 |
-n CONL                                     {1:1}  g7:CONL
+n CONL                                     {1:1}  g7.1:CONL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
 |
-n ENDL                                     {1:1}  g7:ENDL
+n ENDL                                     {1:1}  g7.1:ENDL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
 |
-n INIL                                     {1:1}  g7:INIL
+n INIL                                     {1:1}  g7.1:INIL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
 |
-n SLGC                                     {1:1}  g7:SLGC
+n SLGC                                     {1:1}  g7.1:SLGC
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
   +1 FAMC @<XREF:FAM>@                     {1:1}  g7:FAMC
 ]
@@ -978,8 +978,8 @@ Ordinances performed by members of The Church of Jesus Christ of Latter-day Sain
 n <<DATE_VALUE>>                         {0:1}
 n TEMP <Text>                            {0:1}  g7:TEMP
 n <<PLACE_STRUCTURE>>                    {0:1}
-n STAT <Enum>                            {0:1}  g7:ord-STAT
-  +1 DATE <DateExact>                    {1:1}  g7:DATE-exact
+n STAT <Enum>                            {0:1}  g7.1:ord-STAT
+  +1 DATE <DateExact>                    {1:1}  g7.1:DATE-exact
      +2 TIME <Time>                      {0:1}  g7.1:TIME-exact
 n <<NOTE_STRUCTURE>>                     {0:M}
 n <<SOURCE_CITATION>>                    {0:M}
@@ -991,7 +991,7 @@ These ordinances can be performed posthumously by proxy, and the date may reflec
 #### `LDS_SPOUSE_SEALING` :=
 
 ```gedstruct
-n SLGS                                     {1:1}  g7:SLGS
+n SLGS                                     {1:1}  g7.1:SLGS
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
 ```
 
@@ -1017,7 +1017,7 @@ The optional `TITL` substructure supersedes any `OBJE.FILE.TITL` substructures i
 #### `NEGATIVE_ASSERTION` :=
 
 ```gedstruct
-n NO <Enum>                                {1:1}  g7:NO
+n NO <Enum>                                {1:1}  g7.1:NO
   +1 DATE <DatePeriod>                     {0:1}  g7:NO-DATE
      +2 PHRASE <Text>                      {0:1}  g7:PHRASE
   +1 <<NOTE_STRUCTURE>>                    {0:M}
@@ -1137,7 +1137,7 @@ Alternative approaches to representing names are being considered for future ver
 #### `PLACE_STRUCTURE` :=
 
 ```gedstruct
-n PLAC <List:Text>                         {1:1}  g7:PLAC
+n PLAC <List:Text>                         {1:1}  g7.1:PLAC
   +1 FORM <List:Text>                      {0:1}  g7:PLAC-FORM
   +1 LANG <Language>                       {0:1}  g7:LANG
   +1 TRAN <List:Text>                      {0:M}  g7:PLAC-TRAN
@@ -1235,7 +1235,7 @@ A `SOURCE_CITATION` can contain a `NOTE_STRUCTURE`, which in turn can contain a 
 #### `SOURCE_REPOSITORY_CITATION` :=
 
 ```gedstruct
-n REPO @<XREF:REPO>@                       {1:1}  g7:REPO
+n REPO @<XREF:REPO>@                       {1:1}  g7.1:REPO
   +1 <<NOTE_STRUCTURE>>                    {0:M}
   +1 CALN <Special>                        {0:M}  g7:CALN
      +2 MEDI <Enum>                        {0:1}  g7:MEDI

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -236,15 +236,15 @@ An `INDI` record may have multiple `FAMC` substructures pointing to the same `FA
 n @XREF:INDI@ INDI                         {1:1}  g7:record-INDI
   +1 RESN <List:Enum>                      {0:1}  g7:RESN
   +1 <<PERSONAL_NAME_STRUCTURE>>           {0:M}
-  +1 SEX <Enum>                            {0:1}  g7:SEX
+  +1 SEX <Enum>                            {0:1}  g7.1:SEX
      +2 EXID <Special>                     {0:M}  g7:EXID
         +3 TYPE <Special>                  {0:1}  g7:EXID-TYPE
   +1 <<INDIVIDUAL_ATTRIBUTE_STRUCTURE>>    {0:M}
   +1 <<INDIVIDUAL_EVENT_STRUCTURE>>        {0:M}
   +1 <<NEGATIVE_ASSERTION>>                {0:M}
   +1 <<LDS_INDIVIDUAL_ORDINANCE>>          {0:M}
-  +1 FAMC @<XREF:FAM>@                     {0:M}  g7:INDI-FAMC
-     +2 PEDI <Enum>                        {0:M}  g7:PEDI
+  +1 FAMC @<XREF:FAM>@                     {0:M}  g7.1:INDI-FAMC
+     +2 PEDI <Enum>                        {0:M}  g7.1:PEDI
         +3 PHRASE <Text>                   {0:1}  g7:PHRASE
         +3 DATE <DateValue>                {0:1}  g7:DATE
      +2 STAT <Enum>                        {0:1}  g7:FAMC-STAT

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -79,7 +79,7 @@ Tag | Name<br/>URI | Description
 `BASM` | Bas Mitzvah<br/>`g7:BASM` | The ceremonial event held when a Jewish girl reaches age 13, also known as "Bat Mitzvah."
 `BIRT` | birth<br/>`g7:BIRT` | Entering into life.
 `BLES` | blessing<br/>`g7:BLES` | Bestowing divine care or intercession. Sometimes given in connection with a naming ceremony.
-`BURI` | depositing remains<br/>`g7:BURI` | Depositing the mortal remains of a deceased person.
+`BURI` | depositing remains<br/>`g7.1:BURI` | Depositing the mortal remains of a deceased person.
 `CENS` | census<br/>`g7:INDI-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
 `CHR` | christening<br/>`g7:CHR` | Baptism or naming events for a child.
 `CHRA` | adult christening<br/>`g7:CHRA` | Baptism or naming events for an adult person.
@@ -102,15 +102,15 @@ In addition, `INDI`.`EVEN` is a structure for a generic individual event. It mus
 
 Tag | Name<br/>URI | Description
 --- | ---- | -----------
-`ANUL` | annulment<br/>`g7:ANUL` | Declaring a marriage void from the beginning (never existed).
-`CENS` | census<br/>`g7:FAM-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
+`ANUL` | annulment<br/>`g7.1:ANUL` | Declaring a marriage void from the beginning (never existed).
+`CENS` | census<br/>`g7.1:FAM-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
 `DIV` | divorce<br/>`g7:DIV` | Dissolving a marriage through civil action.
 `DIVF` | divorce filed<br/>`g7:DIVF` | Filing for a divorce by a spouse.
 `ENGA` | engagement<br/>`g7:ENGA` | Recording or announcing an agreement between 2 people to become married.
 `MARB` | marriage bann<br/>`g7:MARB` | Official public notice given that 2 people intend to marry.
 `MARC` | marriage contract<br/>`g7:MARC` | Recording a formal agreement of marriage, including the prenuptial agreement in which marriage partners reach agreement about the property rights of 1 or both, securing property to their children.
 `MARL` | marriage license<br/>`g7:MARL` | Obtaining a legal license to marry.
-`MARR` | marriage<br/>`g7:MARR` | A legal, common-law, or customary event such as a wedding or marriage ceremony that joins 2 partners to create or extend a family unit.
+`MARR` | marriage<br/>`g7.1:MARR` | A legal, common-law, or customary event such as a wedding or marriage ceremony that joins 2 partners to create or extend a family unit.
 `MARS` | marriage settlement<br/>`g7:MARS` | Creating an agreement between 2 people contemplating marriage, at which time they agree to release or modify property rights that would otherwise arise from the marriage.
 
 In addition, `FAM`.`EVEN` is a structure for a generic family event. It must have a `TYPE` substructure to define what kind of event is being provided.
@@ -144,8 +144,8 @@ In addition, `INDI`.`FACT` is a structure for a generic individual attribute. It
 
 Tag | Name<br/>URI | Description
 ----|--------------|-----------------
-`NCHI` | number of children<br/>`g7:FAM-NCHI` | The number of children that belong to this family.
-`RESI` | residence<br/>`g7:FAM-RESI` | An address or place of residence where a family resided.
+`NCHI` | number of children<br/>`g7.1:FAM-NCHI` | The number of children that belong to this family.
+`RESI` | residence<br/>`g7.1:FAM-RESI` | An address or place of residence where a family resided.
 
 In addition, `FAM`.`FACT` is a structure for a generic family attribute. It must have a `TYPE` substructure to define what kind of attribute is being provided.
 
@@ -245,7 +245,7 @@ Others distribute events and attributes between `INDI` records mutually linked b
 A future version of this specification may adjust the definition of `ALIA`.
 :::
 
-#### `ALIA` (Alias) `g7:SUBM-ALIA`
+#### `ALIA` (Alias) `g7.1:SUBM-ALIA`
 
 Indicates that the user described by the superstructure
 is the same person as the individual described by the referenced `INDI`.
@@ -261,7 +261,7 @@ should select or generate a representative `INDI` for the `SUBM`.`ALIA`.
 Indicates an interest in additional research for ancestors of this individual.
 (See also `DESI`).
 
-#### `ANUL` (Annulment) `g7:ANUL`
+#### `ANUL` (Annulment) `g7.1:ANUL`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
@@ -305,7 +305,7 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `BURI` (Depositing remains) `g7:BURI`
+#### `BURI` (Depositing remains) `g7.1:BURI`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -328,7 +328,7 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 The reasons which precipitated an event.
 It is often used subordinate to a death event to show cause of death, such as might be listed on a death certificate.
 
-#### `CENS` (Census)  `g7:FAM-CENS`
+#### `CENS` (Census)  `g7.1:FAM-CENS`
 
 An [Family Event](#family-events).
 
@@ -574,7 +574,7 @@ Depending on the maintaining authority, an `EXID` may be a unique identifier for
 
 `EXID` identifiers are expected to be unique. Once assigned, an `EXID` identifier should never be re-used for any other purpose.
 
-#### `FAM` (Family record) `g7:record-FAM`
+#### `FAM` (Family record) `g7.1:record-FAM`
 
 See `FAMILY_RECORD`
 
@@ -594,7 +594,7 @@ Implementers should support both representations,
 and should choose between them based on user input or other context beyond that provided in the datasets themselves.
 :::
 
-#### `FACT` (Fact) `g7:FAM-FACT`
+#### `FACT` (Fact) `g7.1:FAM-FACT`
 
 See `g7:INDI-FACT`.
 
@@ -731,7 +731,7 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `INDI` (Individual) `g7:record-INDI`
+#### `INDI` (Individual) `g7.1:record-INDI`
 
 See `INDIVIDUAL_RECORD`.
 
@@ -741,15 +741,15 @@ A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.  Previously, GEDCOM versions 3.0 through 5.3 called this `WAC`; it was not part of 5.4 through 5.5.1.
 FamilySearch GEDCOM 7.0 reintroduced it with the name `INIL` for consistency with `BAPL`, `CONL`, and `ENDL`.
 
-#### `KIND` (Kind) `g7:BURI-KIND`
+#### `KIND` (Kind) `g7.1:BURI-KIND`
 
-An enumerated value from set `g7:enumset-BURI-KIND` indicating what was done with the remains of the deceased.
+An enumerated value from set `g7.1:enumset-BURI-KIND` indicating what was done with the remains of the deceased.
 
 Note `KIND` does not have a `g7:PHRASE` substructure; the `g7:TYPE` substructure of the `KIND`'s superstructure should be used for that purpose instead.
 
-#### `KIND` (Kind) `g7:MARR-KIND`
+#### `KIND` (Kind) `g7.1:MARR-KIND`
 
-An enumerated value from set `g7:enumset-MARR-KIND` indicating what kind of marriage the superstructure describes.
+An enumerated value from set `g7.1:enumset-MARR-KIND` indicating what kind of marriage the superstructure describes.
 
 Note `KIND` does not have a `g7:PHRASE` substructure; the `g7:TYPE` substructure of the `KIND`'s superstructure should be used for that purpose instead.
 
@@ -875,7 +875,7 @@ See also `FAMILY_EVENT_STRUCTURE`.
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `MARR` (Marriage) `g7:MARR`
+#### `MARR` (Marriage) `g7.1:MARR`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
@@ -887,7 +887,7 @@ See also `FAMILY_EVENT_STRUCTURE`.
 
 #### `MEDI` (Medium) `g7:MEDI`
 
-An enumerated value from set `g7:enumset-MEDI` providing information about the media or the medium in which information is stored.
+An enumerated value from set `g7.1:enumset-MEDI` providing information about the media or the medium in which information is stored.
 
 When `MEDI` is a substructure of a `g7:CALN`, it is recommended that its payload describes the medium directly found at that call number rather than a medium from which it was derived.
 
@@ -945,7 +945,7 @@ If needed, `text/html` can be converted to `text/plain` using the following step
 
 The name of the superstructure's subject, represented as a simple string.
 
-#### `NAME` (Name) `g7:INDI-NAME`
+#### `NAME` (Name) `g7.1:INDI-NAME`
 
 A `PERSONAL_NAME_STRUCTURE` with parts, translations, sources, and so forth.
 
@@ -959,7 +959,7 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `NCHI` (Number of children) `g7:FAM-NCHI`
+#### `NCHI` (Number of children) `g7.1:FAM-NCHI`
 
 A [Family Attribute](#family-attributes).
 See also `FAMILY_ATTRIBUTE_STRUCTURE`.
@@ -989,7 +989,7 @@ A specific payload `NO XYZ` should only appear where `XYZ` would be legal.
 
 See `NEGATIVE_ASSERTION` for more.
 
-#### `NOTE` (Note) `g7:NOTE`
+#### `NOTE` (Note) `g7.1:NOTE`
 
 A `NOTE_STRUCTURE`, containing additional information provided by the submitter for understanding the enclosing data.
 
@@ -1203,11 +1203,11 @@ This is metadata about the structure itself, not data about its subject.
 
 See `SOURCE_REPOSITORY_CITATION`.
 
-#### `REPO` (Repository) `g7:record-REPO`
+#### `REPO` (Repository) `g7.1:record-REPO`
 
 See `REPOSITORY_RECORD`.
 
-#### `RESI` (Residence) `g7:FAM-RESI`
+#### `RESI` (Residence) `g7.1:FAM-RESI`
 
 A [Family Attribute](#family-attributes).
 See also `FAMILY_ATTRIBUTE_STRUCTURE`.
@@ -1313,17 +1313,17 @@ See also `LDS_SPOUSE_SEALING`.
 A pointer to a note that is shared by multiple structures.
 See `NOTE_STRUCTURE` for more details.
 
-#### `SNOTE` (Shared note) `g7:record-SNOTE`
+#### `SNOTE` (Shared note) `g7.1:record-SNOTE`
 
 A note that is shared by multiple structures.
 See `SHARED_NOTE_RECORD` for more details.
 
-#### `SOUR` (Source) `g7:SOUR`
+#### `SOUR` (Source) `g7.1:SOUR`
 
 A description of the relevant part of a source to support the superstructure's data.
 See `SOURCE_CITATION` for more details.
 
-#### `SOUR` (Source) `g7:record-SOUR`
+#### `SOUR` (Source) `g7.1:record-SOUR`
 
 A description of an entire source.
 See `SOURCE_RECORD` for more details.
@@ -1362,7 +1362,7 @@ An enumerated value from set `g7:enumset-FAMC-STAT` assessing of the state or co
 A contributor of information in the substructure.
 This is metadata about the structure itself, not data about its subject.
 
-#### `SUBM` (Submitter) `g7:record-SUBM`
+#### `SUBM` (Submitter) `g7.1:record-SUBM`
 
 A description of a contributor of information to the document.
 See `SUBMITTER_RECORD` for more details.
@@ -1391,11 +1391,11 @@ This should be, from the evidence point of view, "what the original record keepe
 
 A `Time` value in a 24-hour clock format.
 
-#### `TIME` (Time) `g7:TIME-exact`
+#### `TIME` (Time) `g7.1:TIME-exact`
 
 A `Time` value in a 24-hour clock format.
 The time should be presented in UTC and indicate that with a `Z` in the time payload.
-Unlike a `g7:TIME`, no `g7:PHRASE` is permitted under a `g7:TIME-exact`.
+Unlike a `g7:TIME`, no `g7:PHRASE` is permitted under a `g7.1:TIME-exact`.
 
 #### `TITL` (Title) `g7:TITL`
 
@@ -1589,9 +1589,9 @@ Other descriptor values might include, for example,
 See also `FACT` and `EVEN` for additional examples.
 :::
 
-#### `TYPE` (Type) `g7:NAME-TYPE`
+#### `TYPE` (Type) `g7.1:NAME-TYPE`
 
-An enumerated value from set `g7:enumset-NAME-TYPE` indicating the type of the name.
+An enumerated value from set `g7.1:enumset-NAME-TYPE` indicating the type of the name.
 
 #### `TYPE` (Type) `g7:EXID-TYPE`
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -615,7 +615,7 @@ If the attribute being defined was 1 of the person's skills, such as woodworking
 ```
 :::
 
-#### `FAMC` (Family child) `g7:INDI-FAMC`
+#### `FAMC` (Family child) `g7.1:INDI-FAMC`
 
 The family in which an individual appears as a child.
 It is also used with a `g7:FAMC-STAT` substructure to show individuals who are not children of the family.
@@ -1046,7 +1046,7 @@ and the `PAGE` may describe the entire source.
 ```
 :::
 
-#### `PEDI` (Pedigree) `g7:PEDI`
+#### `PEDI` (Pedigree) `g7.1:PEDI`
 
 An enumerated value from set `g7:enumset-PEDI` indicating the type of child-to-family relationship represented by the superstructure.
 
@@ -1294,7 +1294,7 @@ Other DateValue forms may have unreliable effects on sorting. Including a month 
 day is encouraged to help different applications sort dates the same way, as the
 relative ordering of dates with different levels of precision is not well defined.
 
-#### `SEX` (Sex) `g7:SEX`
+#### `SEX` (Sex) `g7.1:SEX`
 
 An enumerated value from set `g7:enumset-SEX` that indicates the sex of the individual at birth.
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -73,28 +73,28 @@ An assertion that an event did not occur should be encoded using the `NO` struct
 
 Tag | Name<br/>URI | Description
 --- | ---- | -----------
-`ADOP` | adoption<br/>`g7:ADOP` | Creation of a legally approved child-parent relationship that does not exist biologically.
-`BAPM` | baptism<br/>`g7:BAPM` | Baptism, performed in infancy or later. (See also [`BAPL`](#latter-day-saint-ordinances) and `CHR`.)
-`BARM` | Bar Mitzvah<br/>`g7:BARM` | The ceremonial event held when a Jewish boy reaches age 13.
-`BASM` | Bas Mitzvah<br/>`g7:BASM` | The ceremonial event held when a Jewish girl reaches age 13, also known as "Bat Mitzvah."
-`BIRT` | birth<br/>`g7:BIRT` | Entering into life.
-`BLES` | blessing<br/>`g7:BLES` | Bestowing divine care or intercession. Sometimes given in connection with a naming ceremony.
+`ADOP` | adoption<br/>`g7.1:ADOP` | Creation of a legally approved child-parent relationship that does not exist biologically.
+`BAPM` | baptism<br/>`g7.1:BAPM` | Baptism, performed in infancy or later. (See also [`BAPL`](#latter-day-saint-ordinances) and `CHR`.)
+`BARM` | Bar Mitzvah<br/>`g7.1:BARM` | The ceremonial event held when a Jewish boy reaches age 13.
+`BASM` | Bas Mitzvah<br/>`g7.1:BASM` | The ceremonial event held when a Jewish girl reaches age 13, also known as "Bat Mitzvah."
+`BIRT` | birth<br/>`g7.1:BIRT` | Entering into life.
+`BLES` | blessing<br/>`g7.1:BLES` | Bestowing divine care or intercession. Sometimes given in connection with a naming ceremony.
 `BURI` | depositing remains<br/>`g7.1:BURI` | Depositing the mortal remains of a deceased person.
-`CENS` | census<br/>`g7:INDI-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
-`CHR` | christening<br/>`g7:CHR` | Baptism or naming events for a child.
-`CHRA` | adult christening<br/>`g7:CHRA` | Baptism or naming events for an adult person.
-`CONF` | confirmation<br/>`g7:CONF` | Conferring full church membership.
-`CREM` | cremation<br/>`g7:CREM` | The act of reducing a dead body to ashes by fire.
-`DEAT` | death<br/>`g7:DEAT` | Mortal life terminates.
-`EMIG` | emigration<br/>`g7:EMIG` | Leaving one's homeland with the intent of residing elsewhere.
-`FCOM` | first communion<br/>`g7:FCOM` | The first act of sharing in the Lord's supper as part of church worship.
-`GRAD` | graduation<br/>`g7:GRAD` | Awarding educational diplomas or degrees to individuals.
-`IMMI` | immigration<br/>`g7:IMMI` | Entering into a new locality with the intent of residing there.
-`NATU` | naturalization<br/>`g7:NATU` | Obtaining citizenship.
-`ORDN` | ordination<br/>`g7:ORDN` | Receiving authority to act in religious matters.
-`PROB` | probate<br/>`g7:PROB` | Judicial determination of the validity of a will. It may indicate several related court activities over several dates.
-`RETI` | retirement<br/>`g7:RETI` | Exiting an occupational relationship with an employer after a qualifying time period.
-`WILL` | will<br/>`g7:WILL` | A legal document treated as an event, by which a person disposes of his or her estate. It takes effect after death. The event date is the date the will was signed while the person was alive. (See also `PROB`)
+`CENS` | census<br/>`g7.1:INDI-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
+`CHR` | christening<br/>`g7.1:CHR` | Baptism or naming events for a child.
+`CHRA` | adult christening<br/>`g7.1:CHRA` | Baptism or naming events for an adult person.
+`CONF` | confirmation<br/>`g7.1:CONF` | Conferring full church membership.
+`CREM` | cremation<br/>`g7.1:CREM` | The act of reducing a dead body to ashes by fire.
+`DEAT` | death<br/>`g7.1:DEAT` | Mortal life terminates.
+`EMIG` | emigration<br/>`g7.1:EMIG` | Leaving one's homeland with the intent of residing elsewhere.
+`FCOM` | first communion<br/>`g7.1:FCOM` | The first act of sharing in the Lord's supper as part of church worship.
+`GRAD` | graduation<br/>`g7.1:GRAD` | Awarding educational diplomas or degrees to individuals.
+`IMMI` | immigration<br/>`g7.1:IMMI` | Entering into a new locality with the intent of residing there.
+`NATU` | naturalization<br/>`g7.1:NATU` | Obtaining citizenship.
+`ORDN` | ordination<br/>`g7.1:ORDN` | Receiving authority to act in religious matters.
+`PROB` | probate<br/>`g7.1:PROB` | Judicial determination of the validity of a will. It may indicate several related court activities over several dates.
+`RETI` | retirement<br/>`g7.1:RETI` | Exiting an occupational relationship with an employer after a qualifying time period.
+`WILL` | will<br/>`g7.1:WILL` | A legal document treated as an event, by which a person disposes of his or her estate. It takes effect after death. The event date is the date the will was signed while the person was alive. (See also `PROB`)
 
 In addition, `INDI`.`EVEN` is a structure for a generic individual event. It must have a `TYPE` substructure to define what kind of event is being provided.
 
@@ -104,14 +104,14 @@ Tag | Name<br/>URI | Description
 --- | ---- | -----------
 `ANUL` | annulment<br/>`g7.1:ANUL` | Declaring a marriage void from the beginning (never existed).
 `CENS` | census<br/>`g7.1:FAM-CENS` | Periodic count of the population for a designated locality, such as a national or state census.
-`DIV` | divorce<br/>`g7:DIV` | Dissolving a marriage through civil action.
-`DIVF` | divorce filed<br/>`g7:DIVF` | Filing for a divorce by a spouse.
-`ENGA` | engagement<br/>`g7:ENGA` | Recording or announcing an agreement between 2 people to become married.
-`MARB` | marriage bann<br/>`g7:MARB` | Official public notice given that 2 people intend to marry.
-`MARC` | marriage contract<br/>`g7:MARC` | Recording a formal agreement of marriage, including the prenuptial agreement in which marriage partners reach agreement about the property rights of 1 or both, securing property to their children.
-`MARL` | marriage license<br/>`g7:MARL` | Obtaining a legal license to marry.
+`DIV` | divorce<br/>`g7.1:DIV` | Dissolving a marriage through civil action.
+`DIVF` | divorce filed<br/>`g7.1:DIVF` | Filing for a divorce by a spouse.
+`ENGA` | engagement<br/>`g7.1:ENGA` | Recording or announcing an agreement between 2 people to become married.
+`MARB` | marriage bann<br/>`g7.1:MARB` | Official public notice given that 2 people intend to marry.
+`MARC` | marriage contract<br/>`g7.1:MARC` | Recording a formal agreement of marriage, including the prenuptial agreement in which marriage partners reach agreement about the property rights of 1 or both, securing property to their children.
+`MARL` | marriage license<br/>`g7.1:MARL` | Obtaining a legal license to marry.
 `MARR` | marriage<br/>`g7.1:MARR` | A legal, common-law, or customary event such as a wedding or marriage ceremony that joins 2 partners to create or extend a family unit.
-`MARS` | marriage settlement<br/>`g7:MARS` | Creating an agreement between 2 people contemplating marriage, at which time they agree to release or modify property rights that would otherwise arise from the marriage.
+`MARS` | marriage settlement<br/>`g7.1:MARS` | Creating an agreement between 2 people contemplating marriage, at which time they agree to release or modify property rights that would otherwise arise from the marriage.
 
 In addition, `FAM`.`EVEN` is a structure for a generic family event. It must have a `TYPE` substructure to define what kind of event is being provided.
 
@@ -124,19 +124,19 @@ Unlike events, the presence of an attribute is sufficient to assert the attribut
 
 Tag | Name<br/>URI | Description
 --- | ---- | -----------
-`CAST` | caste<br/>`g7:CAST` | The name of an individual's rank or status in society which is sometimes based on racial or religious differences, or differences in wealth, inherited rank, profession, or occupation.
-`DSCR` | physical description<br/>`g7:DSCR` | The physical characteristics of a person.
-`EDUC` | education<br/>`g7:EDUC` | Indicator of a level of education attained.
-`IDNO` | identifying number<br/>`g7:IDNO` | A number or other string assigned to identify a person within some significant external system. It must have a `TYPE` substructure to define what kind of identification number is being provided.
-`NATI` | nationality<br/>`g7:NATI` | An individual's national heritage or origin, or other folk, house, kindred, lineage, or tribal interest.
-`NCHI` | number of children<br/>`g7:INDI-NCHI` | The number of children that this person is known to be the parent of (all marriages).
-`NMR` | number of marriages<br/>`g7:NMR` | The number of times this person has participated in a family as a spouse or parent.
-`OCCU` | occupation<br/>`g7:OCCU` | The type of work or profession of an individual.
-`PROP` | property<br/>`g7:PROP` | Pertaining to possessions such as real estate or other property of interest.
-`RELI` | religion<br/>`g7:INDI-RELI` | A religious denomination to which a person is affiliated or for which a record applies.
-`RESI` | residence<br/>`g7:INDI-RESI` | An address or place of residence where an individual resided.
-`SSN` | social security number<br/>`g7:SSN` | A number assigned by the United States Social Security Administration, used for tax identification purposes. It is a type of `IDNO`.
-`TITL` | title<br/>`g7:INDI-TITL` | A formal designation used by an individual in connection with positions of royalty or other social status, such as Grand Duke.
+`CAST` | caste<br/>`g7.1:CAST` | The name of an individual's rank or status in society which is sometimes based on racial or religious differences, or differences in wealth, inherited rank, profession, or occupation.
+`DSCR` | physical description<br/>`g7.1:DSCR` | The physical characteristics of a person.
+`EDUC` | education<br/>`g7.1:EDUC` | Indicator of a level of education attained.
+`IDNO` | identifying number<br/>`g7.1:IDNO` | A number or other string assigned to identify a person within some significant external system. It must have a `TYPE` substructure to define what kind of identification number is being provided.
+`NATI` | nationality<br/>`g7.1:NATI` | An individual's national heritage or origin, or other folk, house, kindred, lineage, or tribal interest.
+`NCHI` | number of children<br/>`g7.1:INDI-NCHI` | The number of children that this person is known to be the parent of (all marriages).
+`NMR` | number of marriages<br/>`g7.1:NMR` | The number of times this person has participated in a family as a spouse or parent.
+`OCCU` | occupation<br/>`g7.1:OCCU` | The type of work or profession of an individual.
+`PROP` | property<br/>`g7.1:PROP` | Pertaining to possessions such as real estate or other property of interest.
+`RELI` | religion<br/>`g7.1:INDI-RELI` | A religious denomination to which a person is affiliated or for which a record applies.
+`RESI` | residence<br/>`g7.1:INDI-RESI` | An address or place of residence where an individual resided.
+`SSN` | social security number<br/>`g7.1:SSN` | A number assigned by the United States Social Security Administration, used for tax identification purposes. It is a type of `IDNO`.
+`TITL` | title<br/>`g7.1:INDI-TITL` | A formal designation used by an individual in connection with positions of royalty or other social status, such as Grand Duke.
 
 In addition, `INDI`.`FACT` is a structure for a generic individual attribute. It must have a `TYPE` substructure to define what kind of attribute is being provided.
 
@@ -162,12 +162,12 @@ This is no longer the case, but when it was the case the following principles he
 
 Tag | Name<br/>URI | Description
 ----|------|-----------------
-`BAPL` | baptism<br/>`g7:BAPL` | The event of baptism performed at age 8 or later by priesthood authority of The Church of Jesus Christ of Latter-day Saints. (See also [`BAPM`](#individual-events))
-`CONL` | confirmation<br/>`g7:CONL` | The religious event by which a person receives membership in The Church of Jesus Christ of Latter-day Saints. (See also [`CONF`](#individual-events))
-`INIL` | initiatory<br/>`g7:INIL` | A religious event where an initiatory ordinance for an individual was performed by priesthood authority in a temple of The Church of Jesus Christ of Latter-day Saints.
-`ENDL` | endowment<br/>`g7:ENDL` | A religious event where an endowment ordinance for an individual was performed by priesthood authority in a temple of The Church of Jesus Christ of Latter-day Saints.
-`SLGC` | sealing child<br/>`g7:SLGC` | A religious event pertaining to the sealing of a child to his or her parents in a temple ceremony of The Church of Jesus Christ of Latter-day Saints.
-`SLGS` | sealing spouse<br/>`g7:SLGS` | A religious event pertaining to the sealing of a husband and wife in a temple ceremony of The Church of Jesus Christ of Latter-day Saints. (See also [`MARR`](#family-events))
+`BAPL` | baptism<br/>`g7.1:BAPL` | The event of baptism performed at age 8 or later by priesthood authority of The Church of Jesus Christ of Latter-day Saints. (See also [`BAPM`](#individual-events))
+`CONL` | confirmation<br/>`g7.1:CONL` | The religious event by which a person receives membership in The Church of Jesus Christ of Latter-day Saints. (See also [`CONF`](#individual-events))
+`INIL` | initiatory<br/>`g7.1:INIL` | A religious event where an initiatory ordinance for an individual was performed by priesthood authority in a temple of The Church of Jesus Christ of Latter-day Saints.
+`ENDL` | endowment<br/>`g7.1:ENDL` | A religious event where an endowment ordinance for an individual was performed by priesthood authority in a temple of The Church of Jesus Christ of Latter-day Saints.
+`SLGC` | sealing child<br/>`g7.1:SLGC` | A religious event pertaining to the sealing of a child to his or her parents in a temple ceremony of The Church of Jesus Christ of Latter-day Saints.
+`SLGS` | sealing spouse<br/>`g7.1:SLGS` | A religious event pertaining to the sealing of a husband and wife in a temple ceremony of The Church of Jesus Christ of Latter-day Saints. (See also [`MARR`](#family-events))
 
 
 
@@ -185,7 +185,7 @@ A short name of a title, description, or name used for sorting, filing, and retr
 The location of, or most relevant to, the subject of the superstructure.
 See `ADDRESS_STRUCTURE` for more details.
 
-#### `ADOP` (Adoption) `g7:ADOP`
+#### `ADOP` (Adoption) `g7.1:ADOP`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -266,7 +266,7 @@ Indicates an interest in additional research for ancestors of this individual.
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `ASSO` (Associates) `g7:ASSO`
+#### `ASSO` (Associates) `g7.1:ASSO`
 
 A pointer to an associated individual.
 See `ASSOCIATION_STRUCTURE` for more details.
@@ -275,32 +275,32 @@ See `ASSOCIATION_STRUCTURE` for more details.
 
 The person, agency, or entity who created the record. For a published work, this could be the author, compiler, transcriber, abstractor, or editor. For an unpublished source, this may be an individual, a government agency, church organization, or private organization.
 
-#### `BAPL` (Baptism, Latter-Day Saint) `g7:BAPL`
+#### `BAPL` (Baptism, Latter-Day Saint) `g7.1:BAPL`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
-#### `BAPM` (Baptism) `g7:BAPM`
+#### `BAPM` (Baptism) `g7.1:BAPM`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `BARM` (Bar Mitzvah) `g7:BARM`
+#### `BARM` (Bar Mitzvah) `g7.1:BARM`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `BASM` (Bas Mitzvah) `g7:BASM`
+#### `BASM` (Bas Mitzvah) `g7.1:BASM`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `BIRT` (Birth) `g7:BIRT`
+#### `BIRT` (Birth) `g7.1:BIRT`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `BLES` (Blessing) `g7:BLES`
+#### `BLES` (Blessing) `g7.1:BLES`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -318,7 +318,7 @@ In the absence of a clarifying `TYPE` substructure it is likely, but not guarant
 An identification or reference description used to file and retrieve items from the holdings of a repository.
 Despite the word "number" in the name, may contain any character, not just digits.
 
-#### `CAST` (Caste)  `g7:CAST`
+#### `CAST` (Caste)  `g7.1:CAST`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -332,12 +332,12 @@ It is often used subordinate to a death event to show cause of death, such as mi
 
 An [Family Event](#family-events).
 
-#### `CENS` (Census)  `g7:INDI-CENS`
+#### `CENS` (Census)  `g7.1:INDI-CENS`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `CHAN` (Change) `g7:CHAN`
+#### `CHAN` (Change) `g7.1:CHAN`
 
 The most recent change to the superstructure.
 This is metadata about the structure itself, not data about its subject.
@@ -347,12 +347,12 @@ See `CHANGE_DATE` for more details.
 
 The child in a family, whether biological, adopted, foster, sealed, or other relationship.
 
-#### `CHRA` (Christening, adult)  `g7:CHRA`
+#### `CHRA` (Christening, adult)  `g7.1:CHRA`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `CHR` (Christening)  `g7:CHR`
+#### `CHR` (Christening)  `g7.1:CHR`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -362,12 +362,12 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 The name of the city used in the address.
 See `ADDRESS_STRUCTURE` for more details.
 
-#### `CONF` (Confirmation)  `g7:CONF`
+#### `CONF` (Confirmation)  `g7.1:CONF`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `CONL` (Confirmation, Latter-Day Saint) `g7:CONL`
+#### `CONL` (Confirmation, Latter-Day Saint) `g7.1:CONL`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
@@ -386,13 +386,13 @@ A copyright statement, as appropriate for the copyright laws applicable to this 
 
 The name of the business, corporation, or person that produced or commissioned the product.
 
-#### `CREA` (Creation) `g7:CREA`
+#### `CREA` (Creation) `g7.1:CREA`
 
 The initial creation of the superstructure.
 This is metadata about the structure itself, not data about its subject.
 See `CREATION_DATE` for more details.
 
-#### `CREM` (Cremation)  `g7:CREM`
+#### `CREM` (Cremation)  `g7.1:CREM`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -437,7 +437,7 @@ while `SOUR`.`DATA` describes the content of the source.
 
 See `g7:DATA`.
 
-#### `DATA` (Data) `g7:HEAD-SOUR-DATA`
+#### `DATA` (Data) `g7.1:HEAD-SOUR-DATA`
 
 The electronic data source or digital repository from which this dataset was exported.
 The payload is the name of that source,
@@ -450,12 +450,12 @@ The payload is a `DateValue`.
 
 See `DATE_VALUE` for more details.
 
-#### `DATE` (Date) `g7:DATE-exact`
+#### `DATE` (Date) `g7.1:DATE-exact`
 
 The principal date of the subject of the superstructure.
 The payload is a `DateExact`.
 
-#### `DATE` (Date) `g7:HEAD-DATE`
+#### `DATE` (Date) `g7.1:HEAD-DATE`
 
 The `DateExact` that this document was created.
 
@@ -467,7 +467,7 @@ The `DatePeriod` during which the event did not occur or the attribute did not a
 
 The `DatePeriod` covered by the entire source; the period during which this source recorded events.
 
-#### `DEAT` (Death) `g7:DEAT`
+#### `DEAT` (Death) `g7.1:DEAT`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -482,22 +482,22 @@ See also `ANCI`.
 An identifier for the system expected to receive this document.
 See `HEAD`.`SOUR` for guidance on choosing identifiers.
 
-#### `DIVF` (Divorce filing) `g7:DIVF`
+#### `DIVF` (Divorce filing) `g7.1:DIVF`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `DIV` (Divorce) `g7:DIV`
+#### `DIV` (Divorce) `g7.1:DIV`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `DSCR` (Description) `g7:DSCR`
+#### `DSCR` (Description) `g7.1:DSCR`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
-#### `EDUC` (Education) `g7:EDUC`
+#### `EDUC` (Education) `g7.1:EDUC`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -513,26 +513,26 @@ If an invalid email address is present upon import, it should be preserved as-is
 The version 5.5.1 specification contained a typo where this tag was sometimes written `EMAI` and sometimes written `EMAIL`. `EMAIL` should be used in version 7.0 and later.
 :::
 
-#### `EMIG` (Emigration) `g7:EMIG`
+#### `EMIG` (Emigration) `g7.1:EMIG`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `ENDL` (Endowment, Latter-Day Saint) `g7:ENDL`
+#### `ENDL` (Endowment, Latter-Day Saint) `g7.1:ENDL`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
-#### `ENGA` (Engagement) `g7:ENGA`
+#### `ENGA` (Engagement) `g7.1:ENGA`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `EVEN` (Event) `g7:FAM-EVEN`
+#### `EVEN` (Event) `g7.1:FAM-EVEN`
 
-See `g7:INDI-EVEN`.
+See `g7.1:INDI-EVEN`.
 
-#### `EVEN` (Event) `g7:INDI-EVEN`
+#### `EVEN` (Event) `g7.1:INDI-EVEN`
 
 An event: a noteworthy happening related to an individual or family.
 If a specific event type exists, it should be used instead of a generic `EVEN` structure.
@@ -596,9 +596,9 @@ and should choose between them based on user input or other context beyond that 
 
 #### `FACT` (Fact) `g7.1:FAM-FACT`
 
-See `g7:INDI-FACT`.
+See `g7.1:INDI-FACT`.
 
-#### `FACT` (Fact) `g7:INDI-FACT`
+#### `FACT` (Fact) `g7.1:INDI-FACT`
 
 A noteworthy attribute or fact concerning an individual or family.
 If a specific attribute type exists, it should be used instead of a generic `FACT` structure.
@@ -631,7 +631,7 @@ The individual or couple that adopted this individual.
 
 Adoption by an individual, rather than a couple, may be represented either by pointing to a `FAM` where that individual is a `HUSB` or `WIFE` and using a `g7:FAMC-ADOP` substructure to indicate which 1 performed the adoption; or by using a `FAM` where the adopting individual is the only `HUSB`/`WIFE`.
 
-#### `FAMS` (Family spouse) `g7:FAMS`
+#### `FAMS` (Family spouse) `g7.1:FAMS`
 
 The family in which an individual appears as a partner.
 See `FAMILY_RECORD` for more details.
@@ -641,7 +641,7 @@ See `FAMILY_RECORD` for more details.
 A fax telephone number appropriate for sending data facsimiles.
 See `PHON` for additional comments on telephone numbers.
 
-#### `FCOM` (First communion) `g7:FCOM`
+#### `FCOM` (First communion) `g7.1:FCOM`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -684,12 +684,12 @@ It is recommended that applications write `GEDC` with its required substructure 
 
 A given or earned name used for official identification of a person.
 
-#### `GRAD` (Graduation) `g7:GRAD`
+#### `GRAD` (Graduation) `g7.1:GRAD`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `HEAD` (Header) `g7:HEAD`
+#### `HEAD` (Header) `g7.1:HEAD`
 
 A pseudo-structure for storing metadata about the document.
 See [The Header and Trailer](#the-header) for more details.
@@ -721,12 +721,12 @@ specific to the individual described by the associated `FAM`'s `HUSB` substructu
 This is a partner in a `FAM` record.
 See `FAMILY_RECORD` for more details.
 
-#### `IDNO` (Identification number) `g7:IDNO`
+#### `IDNO` (Identification number) `g7.1:IDNO`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
-#### `IMMI` (Immigration) `g7:IMMI`
+#### `IMMI` (Immigration) `g7.1:IMMI`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -735,7 +735,7 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
 See `INDIVIDUAL_RECORD`.
 
-#### `INIL` (Initiatory, Latter-Day Saint) `g7:INIL`
+#### `INIL` (Initiatory, Latter-Day Saint) `g7.1:INIL`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.  Previously, GEDCOM versions 3.0 through 5.3 called this `WAC`; it was not part of 5.4 through 5.5.1.
@@ -860,17 +860,17 @@ neither a notion of accuracy
 nor a notion of region size
 (for example, the `MAP` for a place "Belarus" may be anywhere within that nation's 200,000 square kilometer area).
 
-#### `MARB` (Marriage banns) `g7:MARB`
+#### `MARB` (Marriage banns) `g7.1:MARB`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `MARC` (Marriage contract) `g7:MARC`
+#### `MARC` (Marriage contract) `g7.1:MARC`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `MARL` (Marriage license) `g7:MARL`
+#### `MARL` (Marriage license) `g7.1:MARL`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
@@ -880,7 +880,7 @@ See also `FAMILY_EVENT_STRUCTURE`.
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
 
-#### `MARS` (Marriage settlement) `g7:MARS`
+#### `MARS` (Marriage settlement) `g7.1:MARS`
 
 A [Family Event](#family-events).
 See also `FAMILY_EVENT_STRUCTURE`.
@@ -949,12 +949,12 @@ The name of the superstructure's subject, represented as a simple string.
 
 A `PERSONAL_NAME_STRUCTURE` with parts, translations, sources, and so forth.
 
-#### `NATI` (Nationality) `g7:NATI`
+#### `NATI` (Nationality) `g7.1:NATI`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
-#### `NATU` (Naturalization) `g7:NATU`
+#### `NATU` (Naturalization) `g7.1:NATU`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -964,7 +964,7 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 A [Family Attribute](#family-attributes).
 See also `FAMILY_ATTRIBUTE_STRUCTURE`.
 
-#### `NCHI` (Number of children) `g7:INDI-NCHI`
+#### `NCHI` (Number of children) `g7.1:INDI-NCHI`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -973,12 +973,12 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
 A descriptive or familiar name that is used instead of, or in addition to, one’s proper name.
 
-#### `NMR` (Number of marriages) `g7:NMR`
+#### `NMR` (Number of marriages) `g7.1:NMR`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
-#### `NO` (Negative assertion) `g7:NO`
+#### `NO` (Negative assertion) `g7.1:NO`
 
 An enumerated value from set `g7:enumset-NO` identifying something that was not part of the superstructure:
 an event type which did not occur to the superstructure's subject,
@@ -1007,16 +1007,16 @@ Text which appears on a name line after or behind the given and surname parts of
 
 See `MULTIMEDIA_LINK`.
 
-#### `OBJE` (Object) `g7:record-OBJE`
+#### `OBJE` (Object) `g7.1:record-OBJE`
 
 See `MULTIMEDIA_RECORD`.
 
-#### `OCCU` (Occupation) `g7:OCCU`
+#### `OCCU` (Occupation) `g7.1:OCCU`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
-#### `ORDN` (Ordination) `g7:ORDN`
+#### `ORDN` (Ordination) `g7.1:ORDN`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -1124,7 +1124,7 @@ A name given to a foundling orphan might be
 :::
 
 
-#### `PLAC` (Place) `g7:PLAC`
+#### `PLAC` (Place) `g7.1:PLAC`
 
 The principal place in which the superstructure's subject occurred,
 represented as a [List] of jurisdictional entities in a sequence from the lowest to the highest jurisdiction.
@@ -1145,12 +1145,12 @@ This is a placeholder for providing a default `PLAC`.`FORM`, and must not have a
 A code used by a postal service to identify an area to facilitate mail handling.
 See `ADDRESS_STRUCTURE` for more details.
 
-#### `PROB` (Probate) `g7:PROB`
+#### `PROB` (Probate) `g7.1:PROB`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `PROP` (Property) `g7:PROP`
+#### `PROP` (Property) `g7.1:PROP`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -1179,7 +1179,7 @@ Multiple structures describing different aspects of the same subject must not ha
 
 A religious denomination associated with the event or attribute described by the superstructure.
 
-#### `RELI` (Religion) `g7:INDI-RELI`
+#### `RELI` (Religion) `g7.1:INDI-RELI`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -1199,7 +1199,7 @@ Applications are encouraged to prompt the user when a pointer becomes void durin
 
 This is metadata about the structure itself, not data about its subject.
 
-#### `REPO` (Repository) `g7:REPO`
+#### `REPO` (Repository) `g7.1:REPO`
 
 See `SOURCE_REPOSITORY_CITATION`.
 
@@ -1212,10 +1212,10 @@ See `REPOSITORY_RECORD`.
 A [Family Attribute](#family-attributes).
 See also `FAMILY_ATTRIBUTE_STRUCTURE`.
 
-See `g7:INDI-RESI` for comments on the use of payload strings in `RESI` structures.
+See `g7.1:INDI-RESI` for comments on the use of payload strings in `RESI` structures.
 
 
-#### `RESI` (Residence) `g7:INDI-RESI`
+#### `RESI` (Residence) `g7.1:INDI-RESI`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -1238,7 +1238,7 @@ The following two examples show situations where a `RESI` payload may be appropr
 :::
 
 
-#### `RETI` (Retirement) `g7:RETI`
+#### `RETI` (Retirement) `g7.1:RETI`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
@@ -1278,7 +1278,7 @@ The following indicates that a person's best friend was a witness at their bapti
 A container for storing meta-information about the extension tags used in this document.
 See [Extensions](#extensions) for more details.
 
-#### `SDATE` (Sort date) `g7:SDATE`
+#### `SDATE` (Sort date) `g7.1:SDATE`
 
 A date to be used as a sorting hint.
 It is intended for use when the actual date is unknown, but the display order may be dependent on date.
@@ -1298,12 +1298,12 @@ relative ordering of dates with different levels of precision is not well define
 
 An enumerated value from set `g7:enumset-SEX` that indicates the sex of the individual at birth.
 
-#### `SLGC` (Sealing, child) `g7:SLGC`
+#### `SLGC` (Sealing, child) `g7.1:SLGC`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
-#### `SLGS` (Sealing, spouse) `g7:SLGS`
+#### `SLGS` (Sealing, spouse) `g7.1:SLGS`
 
 A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_SPOUSE_SEALING`.
@@ -1328,7 +1328,7 @@ See `SOURCE_CITATION` for more details.
 A description of an entire source.
 See `SOURCE_RECORD` for more details.
 
-#### `SOUR` (Source) `g7:HEAD-SOUR`
+#### `SOUR` (Source) `g7.1:HEAD-SOUR`
 
 An identifier for the product producing this dataset.
 A registration process for these identifiers existed for a time, but no longer does.
@@ -1339,7 +1339,7 @@ Otherwise, a URI owned by the product should be used instead.
 
 A name piece used as a non-indexing pre-part of a surname.
 
-#### `SSN` (Social security number) `g7:SSN`
+#### `SSN` (Social security number) `g7.1:SSN`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -1349,7 +1349,7 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 A geographical division of a larger jurisdictional area, such as a state within the United States of America.
 See `ADDRESS_STRUCTURE` for more details.
 
-#### `STAT` (Status) `g7:ord-STAT`
+#### `STAT` (Status) `g7.1:ord-STAT`
 
 An enumerated value from set `g7:enumset-ord-STAT` assessing of the state or condition of an ordinance.
 
@@ -1419,7 +1419,7 @@ For an unpublished work, including most digital files, titles should be descript
 Some sources may have a citation text that cannot readily be represented using the `SOURCE_RECORD` substructures `AUTH`, `PUBL`, `REPO`, and so on.
 In such cases, the entire citation text may be presented as the payload of the `SOUR`.`TITL`.
 
-#### `TITL` (Title) `g7:INDI-TITL`
+#### `TITL` (Title) `g7.1:INDI-TITL`
 
 An [Individual Attribute](#individual-attributes).
 See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
@@ -1669,7 +1669,7 @@ specific to the individual described by the associated `FAM`'s `WIFE` substructu
 A partner in a `FAM` record.
 See `FAMILY_RECORD` for more details.
 
-#### `WILL` (Will) `g7:WILL`
+#### `WILL` (Will) `g7.1:WILL`
 
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.

--- a/specification/gedcom-3-structures-4-enumerations.md
+++ b/specification/gedcom-3-structures-4-enumerations.md
@@ -15,7 +15,7 @@ Each set of enumeration values has its own URI.
 | `WIFE` | Adopted by the `WIFE` of the `FAM` pointed to by `FAMC`.<br/>The URI of this value is `g7:enum-ADOP-WIFE` |
 | `BOTH` | Adopted by both `HUSB` and `WIFE` of the `FAM` pointed to by `FAMC` |
 
-### `g7:enumset-BURI-KIND`
+### `g7.1:enumset-BURI-KIND`
 
 | Value | Meaning |
 | :---- | :------ |
@@ -37,13 +37,13 @@ these are given generic definitions with URIs constructed by concatenating
 
 | Value  | Meaning                                                |
 | :----- | :----------------------------------------------------- |
-| `CENS` | A census event; either `g7:INDI-CENS` or `g7:FAM-CENS` |
-| `NCHI` | A count of children; either `g7:INDI-NCHI` or `g7:FAM-NCHI` |
-| `RESI` | A residence attribute; either `g7:INDI-RESI` or `g7:FAM-RESI` |
-| `FACT` | A generic attribute; either `g7:INDI-FACT` or `g7:FAM-FACT` |
+| `CENS` | A census event; either `g7:INDI-CENS` or `g7.1:FAM-CENS` |
+| `NCHI` | A count of children; either `g7:INDI-NCHI` or `g7.1:FAM-NCHI` |
+| `RESI` | A residence attribute; either `g7:INDI-RESI` or `g7.1:FAM-RESI` |
+| `FACT` | A generic attribute; either `g7:INDI-FACT` or `g7.1:FAM-FACT` |
 | `EVEN` | A generic event; either `g7:INDI-EVEN` or `g7:FAM-EVEN` |
 
-### `g7:enumset-MARR-KIND`
+### `g7.1:enumset-MARR-KIND`
 
 | Value | Meaning |
 | :---- | :------ |
@@ -53,7 +53,7 @@ these are given generic definitions with URIs constructed by concatenating
 | `RELIGIOUS`  | A religious marriage event, creating a state of marriage via a religious ceremony or registration process  |
 | `OTHER` | A value not listed here; should be paired with a `TYPE` structure |
 
-### `g7:enumset-MEDI`
+### `g7.1:enumset-MEDI`
 
 | Value        | Meaning                           |
 | :----------- | :-------------------------------- |
@@ -88,7 +88,7 @@ This set contains various structure types, with the same tags and URIs used by t
 
 - All individual and family event types except `EVEN`
 
-- The personal name type `g7:INDI-NAME`
+- The personal name type `g7.1:INDI-NAME`
 
 - The name parts `g7:GIVN` and `g7:SURN`
 
@@ -102,8 +102,7 @@ these are given generic definitions with URIs constructed by concatenating
 
 | Value  | Meaning                                                |
 | :----- | :----------------------------------------------------- |
-| `CENS` | A census event; either `g7:INDI-CENS` or `g7:FAM-CENS` |
-
+| `CENS` | A census event; either `g7.1:INDI-CENS` or `g7.1:FAM-CENS` |
 
 ### `g7:enumset-PEDI`
 
@@ -267,7 +266,7 @@ and applications should be prepared to encounter non-current values.
 | `SUBMITTED` | All | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
 | `UNCLEARED` | All | Data for clearing the ordinance request was insufficient. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
 
-### `g7:enumset-NAME-TYPE`
+### `g7.1:enumset-NAME-TYPE`
 
 | Value | Meaning                       |
 | ----- | :---------------------------- |

--- a/specification/gedcom-3-structures-4-enumerations.md
+++ b/specification/gedcom-3-structures-4-enumerations.md
@@ -37,11 +37,11 @@ these are given generic definitions with URIs constructed by concatenating
 
 | Value  | Meaning                                                |
 | :----- | :----------------------------------------------------- |
-| `CENS` | A census event; either `g7:INDI-CENS` or `g7.1:FAM-CENS` |
-| `NCHI` | A count of children; either `g7:INDI-NCHI` or `g7.1:FAM-NCHI` |
-| `RESI` | A residence attribute; either `g7:INDI-RESI` or `g7.1:FAM-RESI` |
-| `FACT` | A generic attribute; either `g7:INDI-FACT` or `g7.1:FAM-FACT` |
-| `EVEN` | A generic event; either `g7:INDI-EVEN` or `g7:FAM-EVEN` |
+| `CENS` | A census event; either `g7.1:INDI-CENS` or `g7.1:FAM-CENS` |
+| `NCHI` | A count of children; either `g7.1:INDI-NCHI` or `g7.1:FAM-NCHI` |
+| `RESI` | A residence attribute; either `g7.1:INDI-RESI` or `g7.1:FAM-RESI` |
+| `FACT` | A generic attribute; either `g7.1:INDI-FACT` or `g7.1:FAM-FACT` |
+| `EVEN` | A generic event; either `g7.1:INDI-EVEN` or `g7.1:FAM-EVEN` |
 
 ### `g7.1:enumset-MARR-KIND`
 


### PR DESCRIPTION
For issue #364

A large number of URIs changed just due to `NOTE_STRUCTURE` and `SOURCE_CITATION` allowing a `RESN` in 7.1.