### PR TITLE
move <<EVENT_DETAIL>> after AGE

### DIFF
--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -815,9 +815,9 @@ Individual attribute structures vary as follows:
 #### `INDIVIDUAL_EVENT_DETAIL` :=
 
 ```gedstruct
-n <<EVENT_DETAIL>>                         {1:1}
 n AGE <Age>                                {0:1}  g7:AGE
   +1 PHRASE <Text>                         {0:1}  g7:PHRASE
+n <<EVENT_DETAIL>>                         {1:1}
 ```
 
 Substructures shared by most individual events and attributes.


### PR DESCRIPTION
No semantic change, just presentation
In most places <<EVENT_DETAIL>> and its friends comes last in a list, but not in INDIVIDUAL_EVENT_DETAIL. That inconsistency is corrected by this PR.

Fixes #358

(This PR replaces #360)