### PR TITLE
Remove trailing <br/> elements from table-extracted enumeration YAML

### DIFF
--- a/build/uri-def.py
+++ b/build/uri-def.py
@@ -68,6 +68,7 @@ def find_cat_tables(txt, g7, tagsets):
             pfx = bit.group(1)+enum
             if 'The URI of this' in meaning:
                 meaning, tail = meaning.split('The URI of this')
+                if meaning.endswith('<br/>'): meaning = meaning[:-5]
                 pfx = tail.split('`')[1]
             meaning = hard_code.get(pfx,meaning)
             if len(header) > 2:

--- a/extracted-files/tags/enum-ADOP-HUSB
+++ b/extracted-files/tags/enum-ADOP-HUSB
@@ -9,7 +9,7 @@ uri: https://gedcom.io/terms/v7/enum-ADOP-HUSB
 standard tag: HUSB
 
 specification:
-  - Adopted by the `HUSB` of the `FAM` pointed to by `FAMC`.<br/>
+  - Adopted by the `HUSB` of the `FAM` pointed to by `FAMC`.
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ADOP"

--- a/extracted-files/tags/enum-ADOP-WIFE
+++ b/extracted-files/tags/enum-ADOP-WIFE
@@ -9,7 +9,7 @@ uri: https://gedcom.io/terms/v7/enum-ADOP-WIFE
 standard tag: WIFE
 
 specification:
-  - Adopted by the `WIFE` of the `FAM` pointed to by `FAMC`.<br/>
+  - Adopted by the `WIFE` of the `FAM` pointed to by `FAMC`.
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ADOP"


### PR DESCRIPTION
Resolves #395

No semantic change, just a small formatting fix to uri-def.py and the resulting YAML files (only two YAML files impacted)