### PR TITLE
Split g7:SLGC-STAT and g7:SLGS-STAT from g7:ord-STAT

### DIFF
--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -934,19 +934,34 @@ Individual event structures vary as follows:
 [
 n BAPL                                     {1:1}  g7:BAPL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
+  +1 STAT <Enum>                           {0:1}  g7:ord-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 |
 n CONL                                     {1:1}  g7:CONL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
+  +1 STAT <Enum>                           {0:1}  g7:ord-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 |
 n ENDL                                     {1:1}  g7:ENDL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
+  +1 STAT <Enum>                           {0:1}  g7:ord-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 |
 n INIL                                     {1:1}  g7:INIL
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
+  +1 STAT <Enum>                           {0:1}  g7:ord-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 |
 n SLGC                                     {1:1}  g7:SLGC
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
   +1 FAMC @<XREF:FAM>@                     {1:1}  g7:FAMC
+  +1 STAT <Enum>                           {0:1}  g7:SLGC-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 ]
 ```
 
@@ -958,9 +973,6 @@ Ordinances performed by members of The Church of Jesus Christ of Latter-day Sain
 n <<DATE_VALUE>>                         {0:1}
 n TEMP <Text>                            {0:1}  g7:TEMP
 n <<PLACE_STRUCTURE>>                    {0:1}
-n STAT <Enum>                            {0:1}  g7:ord-STAT
-  +1 DATE <DateExact>                    {1:1}  g7:DATE-exact
-     +2 TIME <Time>                      {0:1}  g7:TIME
 n <<NOTE_STRUCTURE>>                     {0:M}
 n <<SOURCE_CITATION>>                    {0:M}
 ```
@@ -973,6 +985,9 @@ These ordinances can be performed posthumously by proxy, and the date may reflec
 ```gedstruct
 n SLGS                                     {1:1}  g7:SLGS
   +1 <<LDS_ORDINANCE_DETAIL>>              {0:1}
+  +1 STAT <Enum>                           {0:1}  g7:SLGS-STAT
+     +2 DATE <DateExact>                   {1:1}  g7:DATE-exact
+        +3 TIME <Time>                     {0:1}  g7:TIME
 ```
 
 Ordinances performed by members of The Church of Jesus Christ of Latter-day Saints; see [Latter-day Saint Ordinances] for descriptions of each ordinance type.

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1317,6 +1317,14 @@ See `ADDRESS_STRUCTURE` for more details.
 
 An enumerated value from set `g7:enumset-ord-STAT` assessing of the state or condition of an ordinance.
 
+#### `STAT` (Status) `g7:SLGC-STAT`
+
+An enumerated value from set `g7:enumset-SLGC-STAT` assessing of the state or condition of an `SLGC` ordinance.
+
+#### `STAT` (Status) `g7:SLGS-STAT`
+
+An enumerated value from set `g7:enumset-SLGS-STAT` assessing of the state or condition of an `SLGS` ordinance.
+
 #### `STAT` (Status) `g7:FAMC-STAT`
 
 An enumerated value from set `g7:enumset-FAMC-STAT` assessing of the state or condition of a researcher's belief in a family connection.

--- a/specification/gedcom-3-structures-4-enumerations.md
+++ b/specification/gedcom-3-structures-4-enumerations.md
@@ -200,20 +200,51 @@ The structures for representing the strength of and confidence in various claims
 These values were formerly used by The Church of Jesus Christ of Latter-day Saints for coordinating between temples and members.
 They are no longer used in that way, meaning their interpretation is subject to individual user interpretation
 
-| Value | Applies to | Meaning                             | Status |
+| Value | Meaning                             | Status |
+| ----- | :---------------------------------- | :----- |
+| `CHILD` | Died before 8 years old, so ordinances other than child to parent sealing are not required. | Current |
+| `COMPLETED` | Completed, but the date is not known. | Deprecated, use `DATE BEF date` instead. This status was defined for use with [TempleReady](https://www.churchofjesuschrist.org/study/ensign/1994/02/news-of-the-church/templeready-now-available) which is no longer in use. |
+| `EXCLUDED` | Patron excluded this ordinance from being cleared in this submission. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `INFANT` | Died before less than 1 year old, baptism or endowment not required. | Deprecated. Use `CHILD` instead. |
+| `PRE_1970` | Ordinance was likely completed because an ordinance for this person was converted from temple records of work completed before 1970. | Deprecated.  Use `DATE BEF 1970` instead. |
+| `STILLBORN` | Born dead, so no ordinances are required. | Current |
+| `SUBMITTED` | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `UNCLEARED` | Data for clearing the ordinance request was insufficient. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+
+### `g7:enumset-SLGC-STAT`
+
+These values were formerly used by The Church of Jesus Christ of Latter-day Saints for coordinating between temples and members.
+They are no longer used in that way, meaning their interpretation is subject to individual user interpretation
+
+| Value | Meaning                             | Status |
+| ----- | :---------------------------------- | :----- |
+| `BIC` | Born in the covenant, so child to parent sealing ordinance is not required. | Current |
+| `COMPLETED` | Completed, but the date is not known. | Deprecated, use `DATE BEF date` instead. This status was defined for use with [TempleReady](https://www.churchofjesuschrist.org/study/ensign/1994/02/news-of-the-church/templeready-now-available) which is no longer in use. |
+| `EXCLUDED` | Patron excluded this ordinance from being cleared in this submission. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `DNS` | This ordinance is not authorized. | Current |
+| `PRE_1970` | Ordinance was likely completed because an ordinance for this person was converted from temple records of work completed before 1970. | Deprecated.  Use `DATE BEF 1970` instead. |
+| `STILLBORN` | Born dead, so no ordinances are required. | Current |
+| `SUBMITTED` | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `UNCLEARED` | Data for clearing the ordinance request was insufficient. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+
+### `g7:enumset-SLGS-STAT`
+
+These values were formerly used by The Church of Jesus Christ of Latter-day Saints for coordinating between temples and members.
+They are no longer used in that way, meaning their interpretation is subject to individual user interpretation
+
+| Value | Meaning                             | Status |
 | ----- | ----------- | :---------------------------------- | :----- |
-| `BIC` | `SLGC` | Born in the covenant, so child to parent sealing ordinance is not required. | Current |
-| `CANCELED` | `SLGS` | Canceled and considered invalid. | Current |
-| `CHILD` | All but `SLGC` | Died before 8 years old, so ordinances other than child to parent sealing are not required. | Current |
-| `COMPLETED` | All | Completed, but the date is not known. | Deprecated, use `DATE BEF date` instead. This status was defined for use with [TempleReady](https://www.churchofjesuschrist.org/study/ensign/1994/02/news-of-the-church/templeready-now-available) which is no longer in use. |
-| `EXCLUDED` | All | Patron excluded this ordinance from being cleared in this submission. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
-| `DNS` | `SLGC`, `SLGS` | This ordinance is not authorized. | Current |
-| `DNS_CAN` | `SLGS` | This ordinance is not authorized, and the previous ordinance is cancelled. | Current |
-| `INFANT` | All but `SLGC` | Died before less than 1 year old, baptism or endowment not required. | Deprecated. Use `CHILD` instead. |
-| `PRE_1970` | All | Ordinance was likely completed because an ordinance for this person was converted from temple records of work completed before 1970. | Deprecated.  Use `DATE BEF 1970` instead. |
-| `STILLBORN` | All | Born dead, so no ordinances are required. | Current |
-| `SUBMITTED` | All | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
-| `UNCLEARED` | All | Data for clearing the ordinance request was insufficient. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `CANCELED` | Canceled and considered invalid. | Current |
+| `CHILD` | Died before 8 years old, so ordinances other than child to parent sealing are not required. | Current |
+| `COMPLETED` | Completed, but the date is not known. | Deprecated, use `DATE BEF date` instead. This status was defined for use with [TempleReady](https://www.churchofjesuschrist.org/study/ensign/1994/02/news-of-the-church/templeready-now-available) which is no longer in use. |
+| `EXCLUDED` | Patron excluded this ordinance from being cleared in this submission. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `DNS` | This ordinance is not authorized. | Current |
+| `DNS_CAN` | This ordinance is not authorized, and the previous ordinance is cancelled. | Current |
+| `INFANT` | Died before less than 1 year old, baptism or endowment not required. | Deprecated. Use `CHILD` instead. |
+| `PRE_1970` | Ordinance was likely completed because an ordinance for this person was converted from temple records of work completed before 1970. | Deprecated.  Use `DATE BEF 1970` instead. |
+| `STILLBORN` | Born dead, so no ordinances are required. | Current |
+| `SUBMITTED` | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
+| `UNCLEARED` | Data for clearing the ordinance request was insufficient. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
 
 ### `g7:enumset-NAME-TYPE`
 


### PR DESCRIPTION
Per GEDCOM Steering Committee discussion on
https://github.com/FamilySearch/GEDCOM.io/issues/106

Note that this does not affect what is permitted in GEDCOM, it just improves the ability of tools to validate what is permitted.