### PR TITLE
Change local file restriction to a recommendation

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -339,7 +339,9 @@ Version 7.0 only supports the following URLs:
 
 - A URL with scheme `ftp`, `http`, or `https` refers to a **web-accessible file**.
 
-- A URL with scheme `file` refers to either a **local file** or a **non-local file**, as defined by [RFC 8089](https://www.rfc-editor.org/info/rfc8089). Local file URLs must not be used in [FamilySearch GEDZIP](#gedzip) nor when sharing datasets on the web or with unknown parties, but may be used for close collaboration between parties with known similar file structures.
+- A URL with scheme `file` refers to either a **local file** or a **non-local file**, as defined by [RFC 8089](https://www.rfc-editor.org/info/rfc8089). Local file URLs must not be used in [FamilySearch GEDZIP](#gedzip)
+    and should be avoided in datasets that are expected to be shared on the web or with unknown parties,
+    but may be appropriate for close collaboration between parties with known similar file structures.
 
 - A URI reference with all of the following:
     - no scheme


### PR DESCRIPTION
This change does technically remove a requirement and thus expand the set of files that the specification describes. However, the requirement it removes was ill-defined and unenforceable, as noted in issue #401, which is why this PR is being submitted as a patch instead of a new minor version.

Resolves issue #401