### PR TITLE
Fix typos

### DIFF
--- a/extracted-files/README.md
+++ b/extracted-files/README.md
@@ -12,7 +12,7 @@ All files in this directory and its sub-directories, except for this README file
 - Various TSV files provide simple look-ups; all of this information is also available in the YAML files
     - `cardinalities.tsv` contains (superstructure type, substructure type, cardinality of substructure) triples.
     - `enumrations.tsv` contains (enumeration set, enumeration value) pairs.
-    - `enumerationsets.tsv` contaisn (structure type, enmeration set) pairs.
+    - `enumerationsets.tsv` contains (structure type, enmeration set) pairs.
     - `payloads.tsv` contains (structure type, payload type) pairs.
     - `substructures.tsv` contains (superstructure type, substructure tag, substructure type) triples.
 

--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -304,13 +304,14 @@ registered values and extension values.
 MediaType = type "/" subtype parameters
 ```
 where:
-* `type` and `subtype` are defined in [RFC 2045](https://www.rfc-editor.org/info/rfc2045)
+
+- `type` and `subtype` are defined in [RFC 2045](https://www.rfc-editor.org/info/rfc2045)
   section 5.1, and registered values (i.e., those not beginning with "x-") are further
   constrained by the definitions in
   [RFC 6838](https://www.rfc-editor.org/info/rfc6838), section 4.2.
   A [registry of media types](https://www.iana.org/assignments/media-types/media-types.xhtml)
   is maintained publicly by the IANA.
-* `parameters` is defined in [RFC 9110](https://www.rfc-editor.org/info/rfc9110),
+- `parameters` is defined in [RFC 9110](https://www.rfc-editor.org/info/rfc9110),
   section 5.6.6.  Note that the `parameters` definition in GEDCOM matches that used by HTTP
   headers which permit whitespace around the ";" delimiter, whereas email headers in
   RFC 2045 do not.


### PR DESCRIPTION
Fix spelling of "contains" in a README file.

Fix formatting in GEDCOM spec caused by lack of a blank line before bulleted list.  The bad formatting can be seen at https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#media-type where it is not displayed as a bulleted list.

Change bullets in source from "*" to "-" just for consistency with rest of source.