### PR TITLE
Add note about oddly formed age payloads

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -225,6 +225,12 @@ Because numbers are rounded down, `>` effectively includes its endpoint; that is
 
 Different cultures count ages differently. Some increment years on the anniversary of birth and others at particular seasons. Some round to the nearest year, others round years down, others round years up. Because users may be unaware of these traditions or may fail to convert them to the round-down convention, errors in age of up to a year are common.
 
+:::note
+Because age payloads are intended to allow recording the age as it was recorded in records that could contain errors,
+odd ages such as `8w 30d`, `1y 400d`, `1y 30m`, etc. are permitted.  Some applications might convert these to more
+standard forms and use a `PHRASE` substructure to hold the original form.
+:::
+
 Age payloads may also be omitted entirely if no suitable form is known but a substructure (such as a `PHRASE`) is desired.
 
 :::note

--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -228,7 +228,7 @@ Different cultures count ages differently. Some increment years on the anniversa
 :::note
 Because age payloads are intended to allow recording the age as it was recorded in records that could contain errors,
 odd ages such as `8w 30d`, `1y 400d`, `1y 30m`, etc. are permitted.  Some applications might convert these to more
-standard forms and use a `PHRASE` substructure to hold the original form.
+standard forms; if so, it is recommended that they use a `PHRASE` substructure to hold the original form.
 :::
 
 Age payloads may also be omitted entirely if no suitable form is known but a substructure (such as a `PHRASE`) is desired.


### PR DESCRIPTION
Add note in the GEDCOM spec about oddly formed age payloads being permitted.

Addresses part of issue #420 

I'm still not entirely happy with this result, especially since `AGE.PHRASE` can always be used to store the original.
The reason I'm not happy is that it means an application must be able to store age payloads with out-of-normal-range values like age in months that requires more than (say) 1 byte to store.  This can cause headaches with application data model design.