### PR TITLE
Add contact info to auto-generated YAML files

### DIFF
--- a/build/uri-def.py
+++ b/build/uri-def.py
@@ -469,6 +469,7 @@ if __name__ == '__main__':
                         is_used_by = True
                     print('  - "'+expand_prefix(tag2,prefixes)+'"', file=fh)
 
+            print('\ncontact: "https://gedcom.io/community/"', file=fh)
             fh.write('...\n')
 
         print('done')

--- a/extracted-files/tags/ABBR
+++ b/extracted-files/tags/ABBR
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADDR
+++ b/extracted-files/tags/ADDR
@@ -109,4 +109,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
   "https://gedcom.io/terms/v7/record-REPO": "{0:1}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADOP
+++ b/extracted-files/tags/ADOP
@@ -48,4 +48,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADOP-FAMC
+++ b/extracted-files/tags/ADOP-FAMC
@@ -28,4 +28,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/ADOP": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADR1
+++ b/extracted-files/tags/ADR1
@@ -30,4 +30,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADR2
+++ b/extracted-files/tags/ADR2
@@ -30,4 +30,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ADR3
+++ b/extracted-files/tags/ADR3
@@ -30,4 +30,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/AGE
+++ b/extracted-files/tags/AGE
@@ -60,4 +60,6 @@ superstructures:
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WIFE": "{1:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/AGNC
+++ b/extracted-files/tags/AGNC
@@ -74,4 +74,6 @@ superstructures:
   "https://gedcom.io/terms/v7/RETI": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ALIA
+++ b/extracted-files/tags/ALIA
@@ -35,4 +35,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ANCI
+++ b/extracted-files/tags/ANCI
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ANUL
+++ b/extracted-files/tags/ANUL
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ASSO
+++ b/extracted-files/tags/ASSO
@@ -103,4 +103,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/AUTH
+++ b/extracted-files/tags/AUTH
@@ -23,4 +23,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BAPL
+++ b/extracted-files/tags/BAPL
@@ -30,4 +30,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BAPM
+++ b/extracted-files/tags/BAPM
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BARM
+++ b/extracted-files/tags/BARM
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BASM
+++ b/extracted-files/tags/BASM
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BIRT
+++ b/extracted-files/tags/BIRT
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BLES
+++ b/extracted-files/tags/BLES
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/BURI
+++ b/extracted-files/tags/BURI
@@ -54,4 +54,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CALN
+++ b/extracted-files/tags/CALN
@@ -23,4 +23,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/REPO": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CAST
+++ b/extracted-files/tags/CAST
@@ -47,4 +47,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CAUS
+++ b/extracted-files/tags/CAUS
@@ -72,4 +72,6 @@ superstructures:
   "https://gedcom.io/terms/v7/RETI": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CHAN
+++ b/extracted-files/tags/CHAN
@@ -38,4 +38,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:1}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CHIL
+++ b/extracted-files/tags/CHIL
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CHR
+++ b/extracted-files/tags/CHR
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CHRA
+++ b/extracted-files/tags/CHRA
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CITY
+++ b/extracted-files/tags/CITY
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CONF
+++ b/extracted-files/tags/CONF
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CONL
+++ b/extracted-files/tags/CONL
@@ -30,4 +30,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CONT
+++ b/extracted-files/tags/CONT
@@ -21,4 +21,6 @@ payload: null
 substructures: {}
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/COPR
+++ b/extracted-files/tags/COPR
@@ -22,4 +22,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/HEAD-SOUR-DATA": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CORP
+++ b/extracted-files/tags/CORP
@@ -26,4 +26,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CREA
+++ b/extracted-files/tags/CREA
@@ -31,4 +31,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:1}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CREM
+++ b/extracted-files/tags/CREM
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CROP
+++ b/extracted-files/tags/CROP
@@ -45,4 +45,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/OBJE": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/CTRY
+++ b/extracted-files/tags/CTRY
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DATA
+++ b/extracted-files/tags/DATA
@@ -26,4 +26,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DATA-EVEN
+++ b/extracted-files/tags/DATA-EVEN
@@ -28,4 +28,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/DATA": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DATA-EVEN-DATE
+++ b/extracted-files/tags/DATA-EVEN-DATE
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/DATA-EVEN": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DATE
+++ b/extracted-files/tags/DATE
@@ -94,4 +94,6 @@ superstructures:
   "https://gedcom.io/terms/v7/SOUR-DATA": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DATE-exact
+++ b/extracted-files/tags/DATE-exact
@@ -25,4 +25,6 @@ superstructures:
   "https://gedcom.io/terms/v7/CREA": "{1:1}"
   "https://gedcom.io/terms/v7/HEAD-SOUR-DATA": "{0:1}"
   "https://gedcom.io/terms/v7/ord-STAT": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DEAT
+++ b/extracted-files/tags/DEAT
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DESI
+++ b/extracted-files/tags/DESI
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DEST
+++ b/extracted-files/tags/DEST
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DIV
+++ b/extracted-files/tags/DIV
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DIVF
+++ b/extracted-files/tags/DIVF
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/DSCR
+++ b/extracted-files/tags/DSCR
@@ -45,4 +45,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/EDUC
+++ b/extracted-files/tags/EDUC
@@ -45,4 +45,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/EMAIL
+++ b/extracted-files/tags/EMAIL
@@ -86,4 +86,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/EMIG
+++ b/extracted-files/tags/EMIG
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ENDL
+++ b/extracted-files/tags/ENDL
@@ -31,4 +31,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ENGA
+++ b/extracted-files/tags/ENGA
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/EXID
+++ b/extracted-files/tags/EXID
@@ -41,4 +41,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/EXID-TYPE
+++ b/extracted-files/tags/EXID-TYPE
@@ -45,4 +45,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/EXID": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-CENS
+++ b/extracted-files/tags/FAM-CENS
@@ -44,4 +44,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-EVEN
+++ b/extracted-files/tags/FAM-EVEN
@@ -41,4 +41,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-FACT
+++ b/extracted-files/tags/FAM-FACT
@@ -41,4 +41,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-HUSB
+++ b/extracted-files/tags/FAM-HUSB
@@ -21,4 +21,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-NCHI
+++ b/extracted-files/tags/FAM-NCHI
@@ -43,4 +43,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-RESI
+++ b/extracted-files/tags/FAM-RESI
@@ -47,4 +47,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAM-WIFE
+++ b/extracted-files/tags/FAM-WIFE
@@ -21,4 +21,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAMC
+++ b/extracted-files/tags/FAMC
@@ -22,4 +22,6 @@ superstructures:
   "https://gedcom.io/terms/v7/BIRT": "{0:1}"
   "https://gedcom.io/terms/v7/CHR": "{0:1}"
   "https://gedcom.io/terms/v7/SLGC": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAMC-ADOP
+++ b/extracted-files/tags/FAMC-ADOP
@@ -24,4 +24,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/ADOP-FAMC": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAMC-STAT
+++ b/extracted-files/tags/FAMC-STAT
@@ -25,4 +25,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/INDI-FAMC": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAMS
+++ b/extracted-files/tags/FAMS
@@ -23,4 +23,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FAX
+++ b/extracted-files/tags/FAX
@@ -74,4 +74,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FCOM
+++ b/extracted-files/tags/FCOM
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FILE
+++ b/extracted-files/tags/FILE
@@ -24,4 +24,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-OBJE": "{1:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FILE-TRAN
+++ b/extracted-files/tags/FILE-TRAN
@@ -65,4 +65,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/FILE": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/FORM
+++ b/extracted-files/tags/FORM
@@ -22,4 +22,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/FILE": "{1:1}"
   "https://gedcom.io/terms/v7/FILE-TRAN": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/GEDC
+++ b/extracted-files/tags/GEDC
@@ -25,4 +25,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/GEDC-VERS
+++ b/extracted-files/tags/GEDC-VERS
@@ -24,4 +24,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/GEDC": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/GIVN
+++ b/extracted-files/tags/GIVN
@@ -21,4 +21,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/GRAD
+++ b/extracted-files/tags/GRAD
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD
+++ b/extracted-files/tags/HEAD
@@ -44,4 +44,6 @@ substructures:
   "https://gedcom.io/terms/v7/SUBM": "{0:1}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-DATE
+++ b/extracted-files/tags/HEAD-DATE
@@ -21,4 +21,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-LANG
+++ b/extracted-files/tags/HEAD-LANG
@@ -44,4 +44,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-PLAC
+++ b/extracted-files/tags/HEAD-PLAC
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-PLAC-FORM
+++ b/extracted-files/tags/HEAD-PLAC-FORM
@@ -20,4 +20,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD-PLAC": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-SOUR
+++ b/extracted-files/tags/HEAD-SOUR
@@ -27,4 +27,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEAD-SOUR-DATA
+++ b/extracted-files/tags/HEAD-SOUR-DATA
@@ -24,4 +24,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HEIGHT
+++ b/extracted-files/tags/HEIGHT
@@ -38,4 +38,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/CROP": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/HUSB
+++ b/extracted-files/tags/HUSB
@@ -36,4 +36,6 @@ superstructures:
   "https://gedcom.io/terms/v7/MARL": "{0:1}"
   "https://gedcom.io/terms/v7/MARR": "{0:1}"
   "https://gedcom.io/terms/v7/MARS": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/IDNO
+++ b/extracted-files/tags/IDNO
@@ -47,4 +47,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/IMMI
+++ b/extracted-files/tags/IMMI
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-CENS
+++ b/extracted-files/tags/INDI-CENS
@@ -43,4 +43,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-EVEN
+++ b/extracted-files/tags/INDI-EVEN
@@ -61,4 +61,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-FACT
+++ b/extracted-files/tags/INDI-FACT
@@ -58,4 +58,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-FAMC
+++ b/extracted-files/tags/INDI-FAMC
@@ -26,4 +26,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-NAME
+++ b/extracted-files/tags/INDI-NAME
@@ -61,4 +61,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-NCHI
+++ b/extracted-files/tags/INDI-NCHI
@@ -43,4 +43,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-RELI
+++ b/extracted-files/tags/INDI-RELI
@@ -40,4 +40,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-RESI
+++ b/extracted-files/tags/INDI-RESI
@@ -66,4 +66,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INDI-TITL
+++ b/extracted-files/tags/INDI-TITL
@@ -40,4 +40,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/INIL
+++ b/extracted-files/tags/INIL
@@ -34,4 +34,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/LANG
+++ b/extracted-files/tags/LANG
@@ -79,4 +79,6 @@ superstructures:
   "https://gedcom.io/terms/v7/PLAC-TRAN": "{1:1}"
   "https://gedcom.io/terms/v7/TEXT": "{0:1}"
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/LATI
+++ b/extracted-files/tags/LATI
@@ -31,4 +31,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/MAP": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/LEFT
+++ b/extracted-files/tags/LEFT
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/CROP": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/LONG
+++ b/extracted-files/tags/LONG
@@ -31,4 +31,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/MAP": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MAP
+++ b/extracted-files/tags/MAP
@@ -29,4 +29,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/PLAC": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MARB
+++ b/extracted-files/tags/MARB
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MARC
+++ b/extracted-files/tags/MARC
@@ -49,4 +49,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MARL
+++ b/extracted-files/tags/MARL
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MARR
+++ b/extracted-files/tags/MARR
@@ -48,4 +48,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MARS
+++ b/extracted-files/tags/MARS
@@ -49,4 +49,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MEDI
+++ b/extracted-files/tags/MEDI
@@ -49,4 +49,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/CALN": "{0:1}"
   "https://gedcom.io/terms/v7/FORM": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/MIME
+++ b/extracted-files/tags/MIME
@@ -79,4 +79,6 @@ superstructures:
   "https://gedcom.io/terms/v7/NOTE-TRAN": "{0:1}"
   "https://gedcom.io/terms/v7/TEXT": "{0:1}"
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NAME
+++ b/extracted-files/tags/NAME
@@ -22,4 +22,6 @@ superstructures:
   "https://gedcom.io/terms/v7/HEAD-SOUR": "{0:1}"
   "https://gedcom.io/terms/v7/record-REPO": "{1:1}"
   "https://gedcom.io/terms/v7/record-SUBM": "{1:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NAME-TRAN
+++ b/extracted-files/tags/NAME-TRAN
@@ -63,4 +63,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NAME-TYPE
+++ b/extracted-files/tags/NAME-TYPE
@@ -24,4 +24,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NATI
+++ b/extracted-files/tags/NATI
@@ -46,4 +46,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NATU
+++ b/extracted-files/tags/NATU
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NICK
+++ b/extracted-files/tags/NICK
@@ -22,4 +22,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NMR
+++ b/extracted-files/tags/NMR
@@ -46,4 +46,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NO
+++ b/extracted-files/tags/NO
@@ -57,4 +57,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NO-DATE
+++ b/extracted-files/tags/NO-DATE
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/NO": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NOTE
+++ b/extracted-files/tags/NOTE
@@ -103,4 +103,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NOTE-TRAN
+++ b/extracted-files/tags/NOTE-TRAN
@@ -69,4 +69,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/NOTE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NPFX
+++ b/extracted-files/tags/NPFX
@@ -21,4 +21,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/NSFX
+++ b/extracted-files/tags/NSFX
@@ -22,4 +22,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/OBJE
+++ b/extracted-files/tags/OBJE
@@ -85,4 +85,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/OCCU
+++ b/extracted-files/tags/OCCU
@@ -45,4 +45,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ORDN
+++ b/extracted-files/tags/ORDN
@@ -46,4 +46,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PAGE
+++ b/extracted-files/tags/PAGE
@@ -52,4 +52,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PEDI
+++ b/extracted-files/tags/PEDI
@@ -25,4 +25,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/INDI-FAMC": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PHON
+++ b/extracted-files/tags/PHON
@@ -82,4 +82,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PHRASE
+++ b/extracted-files/tags/PHRASE
@@ -111,4 +111,6 @@ superstructures:
   "https://gedcom.io/terms/v7/ROLE": "{0:1}"
   "https://gedcom.io/terms/v7/SDATE": "{0:1}"
   "https://gedcom.io/terms/v7/SOUR-EVEN": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PLAC
+++ b/extracted-files/tags/PLAC
@@ -137,4 +137,6 @@ superstructures:
   "https://gedcom.io/terms/v7/SLGS": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PLAC-FORM
+++ b/extracted-files/tags/PLAC-FORM
@@ -34,4 +34,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/PLAC": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PLAC-TRAN
+++ b/extracted-files/tags/PLAC-TRAN
@@ -58,4 +58,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/PLAC": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/POST
+++ b/extracted-files/tags/POST
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PROB
+++ b/extracted-files/tags/PROB
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PROP
+++ b/extracted-files/tags/PROP
@@ -45,4 +45,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/PUBL
+++ b/extracted-files/tags/PUBL
@@ -28,4 +28,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/QUAY
+++ b/extracted-files/tags/QUAY
@@ -26,4 +26,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/REFN
+++ b/extracted-files/tags/REFN
@@ -35,4 +35,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/RELI
+++ b/extracted-files/tags/RELI
@@ -77,4 +77,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/REPO
+++ b/extracted-files/tags/REPO
@@ -29,4 +29,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/RESN
+++ b/extracted-files/tags/RESN
@@ -87,4 +87,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:1}"
   "https://gedcom.io/terms/v7/record-INDI": "{0:1}"
   "https://gedcom.io/terms/v7/record-OBJE": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/RETI
+++ b/extracted-files/tags/RETI
@@ -47,4 +47,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ROLE
+++ b/extracted-files/tags/ROLE
@@ -58,4 +58,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/ASSO": "{1:1}"
   "https://gedcom.io/terms/v7/SOUR-EVEN": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SCHMA
+++ b/extracted-files/tags/SCHMA
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SDATE
+++ b/extracted-files/tags/SDATE
@@ -88,4 +88,6 @@ superstructures:
   "https://gedcom.io/terms/v7/RETI": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SEX
+++ b/extracted-files/tags/SEX
@@ -23,4 +23,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SLGC
+++ b/extracted-files/tags/SLGC
@@ -31,4 +31,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SLGS
+++ b/extracted-files/tags/SLGS
@@ -34,4 +34,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SNOTE
+++ b/extracted-files/tags/SNOTE
@@ -94,4 +94,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SOUR
+++ b/extracted-files/tags/SOUR
@@ -113,4 +113,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
   "https://gedcom.io/terms/v7/record-OBJE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SOUR-DATA
+++ b/extracted-files/tags/SOUR-DATA
@@ -22,4 +22,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SOUR-EVEN
+++ b/extracted-files/tags/SOUR-EVEN
@@ -28,4 +28,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SPFX
+++ b/extracted-files/tags/SPFX
@@ -21,4 +21,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SSN
+++ b/extracted-files/tags/SSN
@@ -46,4 +46,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/STAE
+++ b/extracted-files/tags/STAE
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/ADDR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SUBM
+++ b/extracted-files/tags/SUBM
@@ -23,4 +23,6 @@ superstructures:
   "https://gedcom.io/terms/v7/HEAD": "{0:1}"
   "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
   "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SUBM-LANG
+++ b/extracted-files/tags/SUBM-LANG
@@ -24,4 +24,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/SURN
+++ b/extracted-files/tags/SURN
@@ -21,4 +21,6 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/INDI-NAME": "{0:M}"
   "https://gedcom.io/terms/v7/NAME-TRAN": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TAG
+++ b/extracted-files/tags/TAG
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/SCHMA": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TEMP
+++ b/extracted-files/tags/TEMP
@@ -28,4 +28,6 @@ superstructures:
   "https://gedcom.io/terms/v7/INIL": "{0:1}"
   "https://gedcom.io/terms/v7/SLGC": "{0:1}"
   "https://gedcom.io/terms/v7/SLGS": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TEXT
+++ b/extracted-files/tags/TEXT
@@ -27,4 +27,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/SOUR-DATA": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TIME
+++ b/extracted-files/tags/TIME
@@ -23,4 +23,6 @@ superstructures:
   "https://gedcom.io/terms/v7/DATE-exact": "{0:1}"
   "https://gedcom.io/terms/v7/HEAD-DATE": "{0:1}"
   "https://gedcom.io/terms/v7/SDATE": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TITL
+++ b/extracted-files/tags/TITL
@@ -54,4 +54,6 @@ superstructures:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TOP
+++ b/extracted-files/tags/TOP
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/CROP": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TRLR
+++ b/extracted-files/tags/TRLR
@@ -20,4 +20,6 @@ payload: null
 substructures: {}
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/TYPE
+++ b/extracted-files/tags/TYPE
@@ -108,4 +108,6 @@ superstructures:
   "https://gedcom.io/terms/v7/RETI": "{0:1}"
   "https://gedcom.io/terms/v7/SSN": "{0:1}"
   "https://gedcom.io/terms/v7/WILL": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/UID
+++ b/extracted-files/tags/UID
@@ -108,4 +108,6 @@ superstructures:
   "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/VERS
+++ b/extracted-files/tags/VERS
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/HEAD-SOUR": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/WIDTH
+++ b/extracted-files/tags/WIDTH
@@ -21,4 +21,6 @@ substructures: {}
 
 superstructures:
   "https://gedcom.io/terms/v7/CROP": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/WIFE
+++ b/extracted-files/tags/WIFE
@@ -36,4 +36,6 @@ superstructures:
   "https://gedcom.io/terms/v7/MARL": "{0:1}"
   "https://gedcom.io/terms/v7/MARR": "{0:1}"
   "https://gedcom.io/terms/v7/MARS": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/WILL
+++ b/extracted-files/tags/WILL
@@ -48,4 +48,6 @@ superstructures:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/WWW
+++ b/extracted-files/tags/WWW
@@ -78,4 +78,6 @@ superstructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
   "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
   "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/cal-FRENCH_R
+++ b/extracted-files/tags/cal-FRENCH_R
@@ -55,4 +55,6 @@ months:
   - "https://gedcom.io/terms/v7/month-COMP"
 
 epochs: []
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/cal-GREGORIAN
+++ b/extracted-files/tags/cal-GREGORIAN
@@ -55,4 +55,6 @@ months:
 
 epochs:
   - BCE
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/cal-HEBREW
+++ b/extracted-files/tags/cal-HEBREW
@@ -62,4 +62,6 @@ months:
   - "https://gedcom.io/terms/v7/month-ELL"
 
 epochs: []
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/cal-JULIAN
+++ b/extracted-files/tags/cal-JULIAN
@@ -43,4 +43,6 @@ months:
 
 epochs:
   - BCE
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-0
+++ b/extracted-files/tags/enum-0
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-QUAY"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-1
+++ b/extracted-files/tags/enum-1
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-QUAY"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-2
+++ b/extracted-files/tags/enum-2
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-QUAY"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-3
+++ b/extracted-files/tags/enum-3
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-QUAY"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-ADOP-HUSB
+++ b/extracted-files/tags/enum-ADOP-HUSB
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ADOP"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-ADOP-WIFE
+++ b/extracted-files/tags/enum-ADOP-WIFE
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ADOP"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-ADOPTED
+++ b/extracted-files/tags/enum-ADOPTED
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-PEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-AKA
+++ b/extracted-files/tags/enum-AKA
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-AUDIO
+++ b/extracted-files/tags/enum-AUDIO
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-BIC
+++ b/extracted-files/tags/enum-BIC
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-BIRTH
+++ b/extracted-files/tags/enum-BIRTH
@@ -14,4 +14,6 @@ specification:
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
   - "https://gedcom.io/terms/v7/enumset-PEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-BOOK
+++ b/extracted-files/tags/enum-BOOK
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-BOTH
+++ b/extracted-files/tags/enum-BOTH
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ADOP"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CANCELED
+++ b/extracted-files/tags/enum-CANCELED
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CARD
+++ b/extracted-files/tags/enum-CARD
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CENS
+++ b/extracted-files/tags/enum-CENS
@@ -15,4 +15,6 @@ specification:
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVEN"
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CHALLENGED
+++ b/extracted-files/tags/enum-CHALLENGED
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-FAMC-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CHIL
+++ b/extracted-files/tags/enum-CHIL
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CHILD
+++ b/extracted-files/tags/enum-CHILD
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CLERGY
+++ b/extracted-files/tags/enum-CLERGY
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-COMPLETED
+++ b/extracted-files/tags/enum-COMPLETED
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-CONFIDENTIAL
+++ b/extracted-files/tags/enum-CONFIDENTIAL
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-RESN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-DISPROVEN
+++ b/extracted-files/tags/enum-DISPROVEN
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-FAMC-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-DNS
+++ b/extracted-files/tags/enum-DNS
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-DNS_CAN
+++ b/extracted-files/tags/enum-DNS_CAN
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-ELECTRONIC
+++ b/extracted-files/tags/enum-ELECTRONIC
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-EVEN
+++ b/extracted-files/tags/enum-EVEN
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-EXCLUDED
+++ b/extracted-files/tags/enum-EXCLUDED
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-F
+++ b/extracted-files/tags/enum-F
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-SEX"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FACT
+++ b/extracted-files/tags/enum-FACT
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FATH
+++ b/extracted-files/tags/enum-FATH
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FICHE
+++ b/extracted-files/tags/enum-FICHE
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FILM
+++ b/extracted-files/tags/enum-FILM
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FOSTER
+++ b/extracted-files/tags/enum-FOSTER
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-PEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-FRIEND
+++ b/extracted-files/tags/enum-FRIEND
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-GODP
+++ b/extracted-files/tags/enum-GODP
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-HUSB
+++ b/extracted-files/tags/enum-HUSB
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-IMMIGRANT
+++ b/extracted-files/tags/enum-IMMIGRANT
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-INFANT
+++ b/extracted-files/tags/enum-INFANT
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-LOCKED
+++ b/extracted-files/tags/enum-LOCKED
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-RESN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-M
+++ b/extracted-files/tags/enum-M
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-SEX"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MAGAZINE
+++ b/extracted-files/tags/enum-MAGAZINE
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MAIDEN
+++ b/extracted-files/tags/enum-MAIDEN
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MANUSCRIPT
+++ b/extracted-files/tags/enum-MANUSCRIPT
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MAP
+++ b/extracted-files/tags/enum-MAP
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MARRIED
+++ b/extracted-files/tags/enum-MARRIED
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MOTH
+++ b/extracted-files/tags/enum-MOTH
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-MULTIPLE
+++ b/extracted-files/tags/enum-MULTIPLE
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-NCHI
+++ b/extracted-files/tags/enum-NCHI
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-NEWSPAPER
+++ b/extracted-files/tags/enum-NEWSPAPER
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-NGHBR
+++ b/extracted-files/tags/enum-NGHBR
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-OFFICIATOR
+++ b/extracted-files/tags/enum-OFFICIATOR
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-OTHER
+++ b/extracted-files/tags/enum-OTHER
@@ -16,4 +16,6 @@ value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
   - "https://gedcom.io/terms/v7/enumset-PEDI"
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PARENT
+++ b/extracted-files/tags/enum-PARENT
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PHOTO
+++ b/extracted-files/tags/enum-PHOTO
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PRE_1970
+++ b/extracted-files/tags/enum-PRE_1970
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PRIVACY
+++ b/extracted-files/tags/enum-PRIVACY
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-RESN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PROFESSIONAL
+++ b/extracted-files/tags/enum-PROFESSIONAL
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-NAME-TYPE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-PROVEN
+++ b/extracted-files/tags/enum-PROVEN
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-FAMC-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-RESI
+++ b/extracted-files/tags/enum-RESI
@@ -14,4 +14,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-EVENATTR"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-SEALING
+++ b/extracted-files/tags/enum-SEALING
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-PEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-SPOU
+++ b/extracted-files/tags/enum-SPOU
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-STILLBORN
+++ b/extracted-files/tags/enum-STILLBORN
@@ -15,4 +15,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-SUBMITTED
+++ b/extracted-files/tags/enum-SUBMITTED
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-TOMBSTONE
+++ b/extracted-files/tags/enum-TOMBSTONE
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-U
+++ b/extracted-files/tags/enum-U
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-SEX"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-UNCLEARED
+++ b/extracted-files/tags/enum-UNCLEARED
@@ -16,4 +16,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ord-STAT"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-VIDEO
+++ b/extracted-files/tags/enum-VIDEO
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-MEDI"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-WIFE
+++ b/extracted-files/tags/enum-WIFE
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-WITN
+++ b/extracted-files/tags/enum-WITN
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-ROLE"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enum-X
+++ b/extracted-files/tags/enum-X
@@ -13,4 +13,6 @@ specification:
 
 value of:
   - "https://gedcom.io/terms/v7/enumset-SEX"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-ADOP
+++ b/extracted-files/tags/enumset-ADOP
@@ -10,4 +10,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-ADOP-HUSB"
   - "https://gedcom.io/terms/v7/enum-ADOP-WIFE"
   - "https://gedcom.io/terms/v7/enum-BOTH"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-EVEN
+++ b/extracted-files/tags/enumset-EVEN
@@ -38,4 +38,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/MARL"
   - "https://gedcom.io/terms/v7/MARR"
   - "https://gedcom.io/terms/v7/MARS"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-EVENATTR
+++ b/extracted-files/tags/enumset-EVENATTR
@@ -53,4 +53,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/RELI"
   - "https://gedcom.io/terms/v7/SSN"
   - "https://gedcom.io/terms/v7/TITL"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-FAMC-STAT
+++ b/extracted-files/tags/enumset-FAMC-STAT
@@ -10,4 +10,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-CHALLENGED"
   - "https://gedcom.io/terms/v7/enum-DISPROVEN"
   - "https://gedcom.io/terms/v7/enum-PROVEN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-MEDI
+++ b/extracted-files/tags/enumset-MEDI
@@ -21,4 +21,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-TOMBSTONE"
   - "https://gedcom.io/terms/v7/enum-VIDEO"
   - "https://gedcom.io/terms/v7/enum-OTHER"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-NAME-TYPE
+++ b/extracted-files/tags/enumset-NAME-TYPE
@@ -14,4 +14,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-MARRIED"
   - "https://gedcom.io/terms/v7/enum-PROFESSIONAL"
   - "https://gedcom.io/terms/v7/enum-OTHER"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-PEDI
+++ b/extracted-files/tags/enumset-PEDI
@@ -12,4 +12,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-FOSTER"
   - "https://gedcom.io/terms/v7/enum-SEALING"
   - "https://gedcom.io/terms/v7/enum-OTHER"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-QUAY
+++ b/extracted-files/tags/enumset-QUAY
@@ -11,4 +11,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-1"
   - "https://gedcom.io/terms/v7/enum-2"
   - "https://gedcom.io/terms/v7/enum-3"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-RESN
+++ b/extracted-files/tags/enumset-RESN
@@ -10,4 +10,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-CONFIDENTIAL"
   - "https://gedcom.io/terms/v7/enum-LOCKED"
   - "https://gedcom.io/terms/v7/enum-PRIVACY"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-ROLE
+++ b/extracted-files/tags/enumset-ROLE
@@ -22,4 +22,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-WIFE"
   - "https://gedcom.io/terms/v7/enum-WITN"
   - "https://gedcom.io/terms/v7/enum-OTHER"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-SEX
+++ b/extracted-files/tags/enumset-SEX
@@ -11,4 +11,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-F"
   - "https://gedcom.io/terms/v7/enum-X"
   - "https://gedcom.io/terms/v7/enum-U"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/enumset-ord-STAT
+++ b/extracted-files/tags/enumset-ord-STAT
@@ -19,4 +19,6 @@ enumeration values:
   - "https://gedcom.io/terms/v7/enum-STILLBORN"
   - "https://gedcom.io/terms/v7/enum-SUBMITTED"
   - "https://gedcom.io/terms/v7/enum-UNCLEARED"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-AAV
+++ b/extracted-files/tags/month-AAV
@@ -15,4 +15,6 @@ label: 'Av'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-ADR
+++ b/extracted-files/tags/month-ADR
@@ -15,4 +15,6 @@ label: 'Adar I'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-ADS
+++ b/extracted-files/tags/month-ADS
@@ -15,4 +15,6 @@ label: 'Adar'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-APR
+++ b/extracted-files/tags/month-APR
@@ -16,4 +16,6 @@ label: 'April'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-AUG
+++ b/extracted-files/tags/month-AUG
@@ -16,4 +16,6 @@ label: 'August'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-BRUM
+++ b/extracted-files/tags/month-BRUM
@@ -15,4 +15,6 @@ label: 'Brumaire'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-COMP
+++ b/extracted-files/tags/month-COMP
@@ -15,4 +15,6 @@ label: 'Jour Complémentaires'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-CSH
+++ b/extracted-files/tags/month-CSH
@@ -15,4 +15,6 @@ label: 'Marcheshvan'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-DEC
+++ b/extracted-files/tags/month-DEC
@@ -16,4 +16,6 @@ label: 'December'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-ELL
+++ b/extracted-files/tags/month-ELL
@@ -15,4 +15,6 @@ label: 'Elul'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-FEB
+++ b/extracted-files/tags/month-FEB
@@ -16,4 +16,6 @@ label: 'February'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-FLOR
+++ b/extracted-files/tags/month-FLOR
@@ -15,4 +15,6 @@ label: 'Floréal'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-FRIM
+++ b/extracted-files/tags/month-FRIM
@@ -15,4 +15,6 @@ label: 'Frimaire'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-FRUC
+++ b/extracted-files/tags/month-FRUC
@@ -15,4 +15,6 @@ label: 'Fructidor'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-GERM
+++ b/extracted-files/tags/month-GERM
@@ -15,4 +15,6 @@ label: 'Germinal'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-IYR
+++ b/extracted-files/tags/month-IYR
@@ -15,4 +15,6 @@ label: 'Iyar'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-JAN
+++ b/extracted-files/tags/month-JAN
@@ -16,4 +16,6 @@ label: 'January'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-JUL
+++ b/extracted-files/tags/month-JUL
@@ -16,4 +16,6 @@ label: 'July'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-JUN
+++ b/extracted-files/tags/month-JUN
@@ -16,4 +16,6 @@ label: 'June'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-KSL
+++ b/extracted-files/tags/month-KSL
@@ -15,4 +15,6 @@ label: 'Kislev'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-MAR
+++ b/extracted-files/tags/month-MAR
@@ -16,4 +16,6 @@ label: 'March'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-MAY
+++ b/extracted-files/tags/month-MAY
@@ -16,4 +16,6 @@ label: 'May'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-MESS
+++ b/extracted-files/tags/month-MESS
@@ -15,4 +15,6 @@ label: 'Messidor'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-NIVO
+++ b/extracted-files/tags/month-NIVO
@@ -15,4 +15,6 @@ label: 'Nivôse'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-NOV
+++ b/extracted-files/tags/month-NOV
@@ -16,4 +16,6 @@ label: 'November'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-NSN
+++ b/extracted-files/tags/month-NSN
@@ -15,4 +15,6 @@ label: 'Nisan'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-OCT
+++ b/extracted-files/tags/month-OCT
@@ -16,4 +16,6 @@ label: 'October'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-PLUV
+++ b/extracted-files/tags/month-PLUV
@@ -15,4 +15,6 @@ label: 'Pluviôse'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-PRAI
+++ b/extracted-files/tags/month-PRAI
@@ -15,4 +15,6 @@ label: 'Prairial'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-SEP
+++ b/extracted-files/tags/month-SEP
@@ -16,4 +16,6 @@ label: 'September'
 calendars:
   - "https://gedcom.io/terms/v7/cal-GREGORIAN"
   - "https://gedcom.io/terms/v7/cal-JULIAN"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-SHV
+++ b/extracted-files/tags/month-SHV
@@ -15,4 +15,6 @@ label: 'Shevat'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-SVN
+++ b/extracted-files/tags/month-SVN
@@ -15,4 +15,6 @@ label: 'Sivan'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-THER
+++ b/extracted-files/tags/month-THER
@@ -15,4 +15,6 @@ label: 'Thermidor'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-TMZ
+++ b/extracted-files/tags/month-TMZ
@@ -15,4 +15,6 @@ label: 'Tammuz'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-TSH
+++ b/extracted-files/tags/month-TSH
@@ -15,4 +15,6 @@ label: 'Tishrei'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-TVT
+++ b/extracted-files/tags/month-TVT
@@ -15,4 +15,6 @@ label: 'Tevet'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-HEBREW"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-VEND
+++ b/extracted-files/tags/month-VEND
@@ -15,4 +15,6 @@ label: 'Vendémiaire'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/month-VENT
+++ b/extracted-files/tags/month-VENT
@@ -15,4 +15,6 @@ label: 'Ventôse'
 
 calendars:
   - "https://gedcom.io/terms/v7/cal-FRENCH_R"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/ord-STAT
+++ b/extracted-files/tags/ord-STAT
@@ -29,4 +29,6 @@ superstructures:
   "https://gedcom.io/terms/v7/INIL": "{0:1}"
   "https://gedcom.io/terms/v7/SLGC": "{0:1}"
   "https://gedcom.io/terms/v7/SLGS": "{0:1}"
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-FAM
+++ b/extracted-files/tags/record-FAM
@@ -112,4 +112,6 @@ substructures:
   "https://gedcom.io/terms/v7/UID": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-INDI
+++ b/extracted-files/tags/record-INDI
@@ -121,4 +121,6 @@ substructures:
   "https://gedcom.io/terms/v7/WILL": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-OBJE
+++ b/extracted-files/tags/record-OBJE
@@ -39,4 +39,6 @@ substructures:
   "https://gedcom.io/terms/v7/UID": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-REPO
+++ b/extracted-files/tags/record-REPO
@@ -45,4 +45,6 @@ substructures:
   "https://gedcom.io/terms/v7/WWW": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-SNOTE
+++ b/extracted-files/tags/record-SNOTE
@@ -72,4 +72,6 @@ substructures:
   "https://gedcom.io/terms/v7/UID": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-SOUR
+++ b/extracted-files/tags/record-SOUR
@@ -51,4 +51,6 @@ substructures:
   "https://gedcom.io/terms/v7/UID": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/record-SUBM
+++ b/extracted-files/tags/record-SUBM
@@ -39,4 +39,6 @@ substructures:
   "https://gedcom.io/terms/v7/WWW": "{0:M}"
 
 superstructures: {}
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-Age
+++ b/extracted-files/tags/type-Age
@@ -70,4 +70,6 @@ specification:
     </div>
     
     The URI for the `Age` data type is `https://gedcom.io/terms/v7/type-Age`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-Date
+++ b/extracted-files/tags/type-Date
@@ -122,4 +122,6 @@ specification:
     
     The URI for the `DatePeriod` data type is
     `https://gedcom.io/terms/v7/type-Date#period`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-Enum
+++ b/extracted-files/tags/type-Enum
@@ -50,4 +50,6 @@ specification:
     </div>
     
     The URI for the `Enum` data type is `https://gedcom.io/terms/v7/type-Enum`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-FilePath
+++ b/extracted-files/tags/type-FilePath
@@ -53,4 +53,6 @@ specification:
     
     The URI for the `FilePath` data type is
     `https://gedcom.io/terms/v7/type-FilePath`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-List
+++ b/extracted-files/tags/type-List
@@ -43,4 +43,6 @@ specification:
     
     The URI for the `List:Enum` data type is
     `https://gedcom.io/terms/v7/type-List#Enum`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-Name
+++ b/extracted-files/tags/type-Name
@@ -28,4 +28,6 @@ specification:
     
     The URI for the `PersonalName` data type is
     `https://gedcom.io/terms/v7/type-Name`.
+
+contact: "https://gedcom.io/community/"
 ...

--- a/extracted-files/tags/type-Time
+++ b/extracted-files/tags/type-Time
@@ -32,4 +32,6 @@ specification:
     </div>
     
     The URI for the `Time` data type is `https://gedcom.io/terms/v7/type-Time`.
+
+contact: "https://gedcom.io/community/"
 ...


### PR DESCRIPTION
Per discussion in steering committee meeting 2024-04-04, using <https://gedcom.io/community/> as the contact info because that page describes various means of contact and is expected to be updated from time to time as means of contact change.

Resolves #444 