### PR TITLE
yamllint is recursive

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -23,4 +23,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate YAML
-        run: yamllint .yamllint.yml .github .github/workflows
+        run: yamllint .


### PR DESCRIPTION
Avoid validating the same file multiple times

https://github.com/FamilySearch/GEDCOM/actions/runs/8838156091/job/24268618756 under "Validate YAML" shows multiple occurences of files under .github/workflow since .github and .github/workflow are both passed to yamllint