### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/propagate-main-to-v7.1.yml
+++ b/.github/workflows/propagate-main-to-v7.1.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  merge-to-v7.1:
+  merge-to-v71:
     permissions:
       contents: write  # for Git to git push
       pull-requests: write  # for Git to create a pull request


### PR DESCRIPTION
https://github.com/FamilySearch/GEDCOM/actions/runs/9044561163 failure reports: "The workflow is not valid.
.github/workflows/propagate-main-to-v7.1.yml (Line: 18, Col: 3): The identifier 'merge-to-v7.1' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters."

This PR therefore removes the '.' that is causing the failure.