### PR TITLE
Clarify nickname

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -953,7 +953,9 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 
 #### `NICK` (Nickname) `g7:NICK`
 
-A descriptive or familiar name that is used instead of, or in addition to, one’s proper name.
+A descriptive or familiar name that is used instead of, or in addition to, one’s official or legal name.
+A nickname can be a derivation of another name, such as "Jimmy" fron "James", or a distinct name.
+Nicknames can be brief-lived and informal or used consistently even in formal situations throughout one's life.
 
 #### `NMR` (Number of marriages) `g7:NMR`
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -963,8 +963,11 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 A descriptive or familiar name that is used instead of, or in addition to, one’s official or legal name.
 
 :::note
-Although the label of this structure is "nickname", the definition is limited to descriptive or familiar names, not to other name types sometimes called "nicknames" in English, such as names used in formal settings but not on legal documents.
-However, some applications show users only the text "nickname", so user-entered `NICK` payloads that go beyond the structure's definition may be found in some GEDCOM files.
+The title and description of this structure was introduced with version 5.5 in 1996, but are understood differently by different users.
+Some use NICK only for names that would be inappropriate in formal settings.
+Some use it for pseudonyms regardless of where they are used.
+Some use it for any variant of a name that is not the one used on legal documents 
+Because all of these uses, and likely others as well, are common in existing data, no further clarification of the meaning of the NICK structure is possible without contradicting some existing data.
 :::
 
 #### `NMR` (Number of marriages) `g7:NMR`

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -963,11 +963,11 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 A descriptive or familiar name that is used instead of, or in addition to, one’s official or legal name.
 
 :::note
-The title and description of this structure was introduced with version 5.5 in 1996, but are understood differently by different users.
-Some use NICK only for names that would be inappropriate in formal settings.
+The label "nickname" and description text of this structure were introduced with version 5.5 in 1996, but are understood differently by different users.
+Some use `NICK` only for names that would be inappropriate in formal settings.
 Some use it for pseudonyms regardless of where they are used.
-Some use it for any variant of a name that is not the one used on legal documents 
-Because all of these uses, and likely others as well, are common in existing data, no further clarification of the meaning of the NICK structure is possible without contradicting some existing data.
+Some use it for any variant of a name that is not the one used on legal documents.
+Because all of these uses, and likely others as well, are common in existing data, no further clarification of the meaning of the `NICK` structure is possible without contradicting some existing data.
 :::
 
 #### `NMR` (Number of marriages) `g7:NMR`

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -954,7 +954,7 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 #### `NICK` (Nickname) `g7:NICK`
 
 A descriptive or familiar name that is used instead of, or in addition to, one’s official or legal name.
-A nickname can be a derivation of another name, such as "Jimmy" fron "James", or a distinct name.
+A nickname can be a derivation of another name, such as "Jimmy" from "James", or a distinct name.
 Nicknames can be brief-lived and informal or used consistently even in formal situations throughout one's life.
 
 #### `NMR` (Number of marriages) `g7:NMR`

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -954,8 +954,11 @@ See also `INDIVIDUAL_ATTRIBUTE_STRUCTURE`.
 #### `NICK` (Nickname) `g7:NICK`
 
 A descriptive or familiar name that is used instead of, or in addition to, one’s official or legal name.
-A nickname can be a derivation of another name, such as "Jimmy" from "James", or a distinct name.
-Nicknames can be brief-lived and informal or used consistently even in formal situations throughout one's life.
+
+:::note
+Although the label of this structure is "nickname", the definition is limited to descriptive or familiar names, not to other name types sometimes called "nicknames" in English, such as names used in formal settings but not on legal documents.
+However, some applications show users only the text "nickname", so user-entered `NICK` payloads that go beyond the structure's definition may be found in some GEDCOM files.
+:::
 
 #### `NMR` (Number of marriages) `g7:NMR`
 


### PR DESCRIPTION
Add additional clarification to nickname, explaining the word's meaning in English which is not shared by several European countries. See [this comment](https://github.com/FamilySearch/GEDCOM/issues/473#issuecomment-2168463707) and the rest of issue #473 for more on why this clarification is needed.

Although #473's discussion covers many more topics, if we go back to the title and first question in the issue I think this resolves #473.