### PR TITLE
Define "principle date"

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -437,6 +437,13 @@ with substructures providing additional details about the source (not the export
 The principal date of the subject of the superstructure.
 The payload is a `DateValue`.
 
+When the superstructure is an event, the principle date indicates when the event took place.
+
+When the superstrucutre is an attribute, the principle date indicates when the attribute was observed, asserted, or applied.
+A date period might put bounds on the attributes applicability, but other date forms assume that the attribute may have also applied on other dates too.
+
+When the superstructure is a `g7:SOUR-DATA`, the principle date indiates when the data was entered into the source; or, for a source like a website that changes over time, a date on which the source contained the data.
+
 See `DATE_VALUE` for more details.
 
 #### `DATE` (Date) `g7:DATE-exact`

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -437,12 +437,12 @@ with substructures providing additional details about the source (not the export
 The principal date of the subject of the superstructure.
 The payload is a `DateValue`.
 
-When the superstructure is an event, the principle date indicates when the event took place.
+When the superstructure is an event, the principal date indicates when the event took place.
 
-When the superstrucutre is an attribute, the principle date indicates when the attribute was observed, asserted, or applied.
+When the superstructure is an attribute, the principal date indicates when the attribute was observed, asserted, or applied.
 A date period might put bounds on the attributes applicability, but other date forms assume that the attribute may have also applied on other dates too.
 
-When the superstructure is a `g7:SOUR-DATA`, the principle date indiates when the data was entered into the source; or, for a source like a website that changes over time, a date on which the source contained the data.
+When the superstructure is a `g7:SOUR-DATA`, the principle date indicates when the data was entered into the source; or, for a source like a website that changes over time, a date on which the source contained the data.
 
 See `DATE_VALUE` for more details.
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -442,7 +442,7 @@ When the superstructure is an event, the principal date indicates when the event
 When the superstructure is an attribute, the principal date indicates when the attribute was observed, asserted, or applied.
 A date period might put bounds on the attributes applicability, but other date forms assume that the attribute may have also applied on other dates too.
 
-When the superstructure is a `g7:SOUR-DATA`, the principle date indicates when the data was entered into the source; or, for a source like a website that changes over time, a date on which the source contained the data.
+When the superstructure is a `g7:SOUR-DATA`, the principal date indicates when the data was entered into the source; or, for a source like a website that changes over time, a date on which the source contained the data.
 
 See `DATE_VALUE` for more details.
 


### PR DESCRIPTION
As pointed out in #488 and #490, the definition of DATE is unclear. In particular, it hinges on the the vague phrase "principle date" which could use some clarification. This is my effort to provide that clarification.

Note, if competing definitions of the principle date in these contexts exists then this suggestion could be seen as backwards-incompatible and may need to be reworded as a non-normative recommendation or note. That said, I'm not aware of any conflicting definitions.

Resolves #490