### PR TITLE
Adding SPLAC beside PLAC

### DIFF
--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -425,7 +425,7 @@ Information is copied into the new chain of `SPLAC` records as follows:
 - The `FORM` payload parts (which may be copied from the `HEAD`.`PLAC`.`FORM` if that is present but `PLAC`.`FORM` is not) become `SPLAC`.`TYPE` payloads
 - The `TRAN` payload parts become `TRAN` payloads
 - `LANG` and `TRAN`.`LANG` are copied to each record in the linked list
-- All other substructures (`MAP`, `EXID`, `NOTE`) are copied only to the first record in the list.
+- All other substructures (`MAP` and `EXID`) are copied only to the first record in the list.
 
 :::example
 
@@ -1288,6 +1288,25 @@ An assertion that something took place in or is part of some place.
 
 The `NOTE`s here are about the connection between the topic of the superstructure and the pointed-to place.
 Notes about the place itself should be placed inside the pointed-to `SHARED_PLACE_RECORD`.
+
+A `voidPtr` and `PHRASE` can be used to describe places not referenced by any `SPLAC` record, but so can a `PLAC` structure. Using a `voidPtr` with `SPLAC` is not recommended.
+
+:::example
+The following both indicate that a birth happened "at home" with no additional details on where that was. The second version is preferred; the first should not be used.
+
+```gedcom
+0 @I1@ INDI
+1 BIRT
+2 SPLAC @VOID@
+3 PHRASE at home
+```
+
+```gedcom
+0 @I1@ INDI
+1 BIRT
+2 PLAC at home
+```
+:::
 
 See `SHARED_PLACE_RECORD` for how to convert between `PLAC` and `SPLAC`.
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1308,6 +1308,16 @@ See `NOTE_STRUCTURE` for more details.
 A note that is shared by multiple structures.
 See `SHARED_NOTE_RECORD` for more details.
 
+#### `SPLAC` (Shared place) `g7:SPLAC`
+
+A pointer to a place that is shared by multiple structures.
+See `SHARED_PLACE_STRUCTURE` for more details.
+
+#### `SPLAC` (Shared place) `g7:record-SPLAC`
+
+A place that is shared by multiple structures.
+See `SHARED_PLACE_RECORD` for more details.
+
 #### `SOUR` (Source) `g7:SOUR`
 
 A description of the relevant part of a source to support the superstructure's data.
@@ -1429,6 +1439,22 @@ Each `TRAN` substructure must have either a language tag or a media type or both
 Each `TRAN` structure must differ from its superstructure
 and from every other `TRAN` substructure of its superstructure
 in either its language tag or its media type or both.
+
+#### `TRAN` (Translation) `g7:TRAN`
+
+A type of `TRAN` substructure for generic text-valued structures.
+Each `TRAN` must have a `LANG` substructure.
+
+:::example
+The following presents the name of a nation in both German and English
+
+```gedcom
+0 @SP1@ SPLAC Bundesrepublik Deutschland 
+1 LANG de
+1 TRAN Federal Republic of Germany
+2 LANG en
+```
+:::
 
 #### `TRAN` (Translation) `g7:NAME-TRAN`
 
@@ -1597,6 +1623,23 @@ Registered URIs are listed in [exid-types.json](https://github.com/FamilySearch/
 
 Additional type URIs can be registered by filing a
 [GitHub pull request](https://github.com/FamilySearch/GEDCOM/pulls).
+
+#### `TYPE` (Type) `g71:SPLAC-TYPE`
+
+A jurisdictional title, describing what type of jurisdiction the superstructure has.
+Because of the wide variety of jurisdictional titles in use,
+this is a free-text value and generally presented in the same language as the place's name.
+
+:::example
+The following represents that Baltimore is a city.
+
+```gedcom
+0 @SP2@ SPLAC Baltimore
+1 TYPE City
+```
+:::
+
+See also `g7:PLAC-FORM` which is the list version of `g71:SPLAC-TYPE`.
 
 #### `UID` (Unique Identifier) `g7:UID`
 


### PR DESCRIPTION
Conversation draft of adding place records to 7.1

This puts PLAC and SPLAC side-by-side, like NOTE and SNOTE. That is not the only possibility, and alternative PRs with other designs are anticipated to allow better comparison of the options.

This only addresses the record-vs-substucture topic. The additional substuctures that have also been considered for location records (for example, see [GEDCOM-L's _LOC extension](https://genealogy.net/GEDCOM/GEDCOM551%20GEDCOM-L%20Addendum-R2.pdf#page=13)) would presumably be added to the new `<<PLACE_DETIALS>>` production in a future PR if we decide that this organization is the right approach.
