### PR TITLE
Fix documentation confusion about HEAD-SOUR-DATA

### DIFF
--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -166,7 +166,7 @@ A few substructures of note:
 - `SCHMA` gives the meaning of extension tags; see [Extensions](#extensions) for more details.
 - `SOUR` describes the originating software.
     - `CORP` describes the corporation creating the software.
-    - `HEAD`.`SOUR`.`DATA` describes a larger database this data is extracted from.
+    - `HEAD`.`SOUR`.`DATA` describes a larger database, data source, or digital repository this data is extracted from.
 - `LANG` and `PLAC` give a default value for the rest of the document.
 
 

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -169,6 +169,9 @@ A few substructures of note:
     - `HEAD`.`SOUR`.`DATA` describes a larger database, data source, or digital repository this data is extracted from.
 - `LANG` and `PLAC` give a default value for the rest of the document.
 
+:::deprecation
+`HEAD`.`SOUR`.`DATA` is now deprecated and applications should use `HEAD`.`SOUR`.`NAME` instead.
+:::
 
 ### Records
 

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -166,7 +166,7 @@ A few substructures of note:
 - `SCHMA` gives the meaning of extension tags; see [Extensions](#extensions) for more details.
 - `SOUR` describes the originating software.
     - `CORP` describes the corporation creating the software.
-    - `HEAD`.`SOUR`.`DATA` describes a larger database, data source, or digital repository this data is extracted from.
+    - `HEAD`.`SOUR`.`DATA` describes a larger database, electronic data source, or digital repository this data is extracted from.
 - `LANG` and `PLAC` give a default value for the rest of the document.
 
 :::deprecation

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -429,7 +429,7 @@ See `g7:DATA`.
 #### `DATA` (Data) `g7:HEAD-SOUR-DATA`
 
 The database, electronic data source, or digital repository from which this dataset was exported.
-The payload is the name of the database, data source, or digital repository,
+The payload is the name of the database, electronic data source, or digital repository,
 with substructures providing additional details about it (not about the export).
 
 #### `DATE` (Date) `g7:DATE`

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -428,7 +428,7 @@ See `g7:DATA`.
 
 #### `DATA` (Data) `g7:HEAD-SOUR-DATA`
 
-The electronic database, data source, or digital repository from which this dataset was exported.
+The database, electronic data source, or digital repository from which this dataset was exported.
 The payload is the name of the database, data source, or digital repository,
 with substructures providing additional details about it (not about the export).
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -428,9 +428,9 @@ See `g7:DATA`.
 
 #### `DATA` (Data) `g7:HEAD-SOUR-DATA`
 
-The electronic data source or digital repository from which this dataset was exported.
-The payload is the name of that source,
-with substructures providing additional details about the source (not the export).
+The electronic database, data source, or digital repository from which this dataset was exported.
+The payload is the name of the database, data source, or digital repository,
+with substructures providing additional details about it (not about the export).
 
 #### `DATE` (Date) `g7:DATE`
 


### PR DESCRIPTION
* Make HEAD.SOUR.DATA wording consistent between two places in spec
* Deprecate HEAD.SOUR.DATA in favor of just using HEAD.SOUR.NAME

Fixes #549