### PR TITLE
add GOV ID to exid-types

### DIFF
--- a/exid-types.json
+++ b/exid-types.json
@@ -106,9 +106,9 @@
     "reference": "https://www.wikitree.com/wiki/Help:WikiTree_ID"
   },
   {
-    "label": "GOV ID",
+    "label": "GOV Historic Gazeteer ID",
     "type": "http://gov.genealogy.net/",
-    "description": "Historical Gazeteer place ID",
+    "description": "Historic Gazeteer place ID",
     "contact": "gov-support@genealogy.net",
     "change-controller": "CompGen",
     "reference": "https://wiki.genealogy.net/GOV"

--- a/exid-types.json
+++ b/exid-types.json
@@ -80,7 +80,7 @@
     "contact": "GEDCOM@familysearch.org",
     "change-controller": "FindAGrave.com",
     "reference": "https://support.findagrave.com/s/article/Cemetery-Search"
-  }
+  },
   {
     "label": "BillionGraves Grave ID",
     "type": "https://www.billiongraves.com/grave/name/",
@@ -96,7 +96,7 @@
     "contact": "GEDCOM@familysearch.org",
     "change-controller": "BillionGraves.com",
     "reference": "https://billiongraves.com/search/cemetery"
-  }
+  },
   {
     "label": "WikiTree Person ID",
     "type": "https://www.wikitree.com/wiki/",
@@ -105,4 +105,12 @@
     "change-controller": "wikitree.com",
     "reference": "https://www.wikitree.com/wiki/Help:WikiTree_ID"
   },
+  {
+    "label": "GOV ID",
+    "type": "http://gov.genealogy.net/",
+    "description": "Historical Gazeteer place ID",
+    "contact": "gov-support@genealogy.net",
+    "change-controller": "CompGen",
+    "reference": "https://gedcom.io/exid-type/GOV-ID"
+  }
 ]

--- a/exid-types.json
+++ b/exid-types.json
@@ -111,6 +111,6 @@
     "description": "Historical Gazeteer place ID",
     "contact": "gov-support@genealogy.net",
     "change-controller": "CompGen",
-    "reference": "https://gedcom.io/exid-type/GOV-ID"
+    "reference": "https://wiki.genealogy.net/GOV"
   }
 ]


### PR DESCRIPTION
Register gov.genealogy.net, a historical gazeteer maintained by CompGen, using information provided by @albertemmerich

See also https://github.com/FamilySearch/GEDCOM-registries/pull/96