### PR TITLE
Personal names are not required to start with a "1".

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -281,7 +281,7 @@ PersonalName = nameStr
              / [nameStr] "/" [nameStr] "/" [nameStr]
 
 nameChar     = %x20-2E / %x30-10FFFF  ; any but '/' and '\t'
-nameStr      = 1*nameChar
+nameStr      = *nameChar
 ```
 
 The character U+002F (`/`, slash or solidus) has special meaning in a personal name, being used to delimit the portion of the name that most closely matches the concept of a surname, family name, or the like.


### PR DESCRIPTION
This is a minor error in the specification. By using `1*nameChar`, this would mean that "John Doe" is illegal, but "1John Doe" is okay.

This is unlikely to be intentional.