### PR TITLE
Create exid-types.json to redirect to registries

### DIFF
--- a/exid-types.json
+++ b/exid-types.json
@@ -1,5 +1,5 @@
 {
     "error": "This file has been removed",
     "replaced by": "https://github.com/FamilySearch/GEDCOM-registries/tree/main/uri/exid-types",
-    "rationale": "This file contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more."
+    "rationale": "This file previously contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more."
 }

--- a/exid-types.json
+++ b/exid-types.json
@@ -1,0 +1,5 @@
+{
+    "error": "This file has been removed",
+    "replaced by": "https://github.com/FamilySearch/GEDCOM-registries/tree/main/uri/exid-types",
+    "rationale": "This file contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more."
+}

--- a/exid-types.json
+++ b/exid-types.json
@@ -1,5 +1,5 @@
 {
     "error": "This file has been removed",
     "replaced by": "https://github.com/FamilySearch/GEDCOM-registries/tree/main/uri/exid-types",
-    "rationale": "This file previously contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more."
+    "rationale": "This file previously contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more information about this change."
 }

--- a/exid-types.json
+++ b/exid-types.json
@@ -1,5 +1,5 @@
 {
     "error": "This file has been removed",
     "replaced by": "https://github.com/FamilySearch/GEDCOM-registries/tree/main/uri/exid-types",
-    "rationale": "This file previously contained an incomplete and inconsistent subset of the YAML files in the registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more information about this change."
+    "rationale": "This file previously contained an incomplete and inconsistent subset of information now found the YAML files in the GEDCOM registries. See https://github.com/FamilySearch/GEDCOM/pull/576 for more information about this change."
 }


### PR DESCRIPTION
Because several previous versions of the specification linked to `exid-types.json`, this re-adds it with information to link readers to the current information. This is intended to resolve #581 