### PR TITLE
Clarify ELECTRONIC is used for a scan

### DIFF
--- a/specification/gedcom-3-structures-4-enumerations.md
+++ b/specification/gedcom-3-structures-4-enumerations.md
@@ -56,7 +56,7 @@ these are given generic definitions with URIs constructed by concatenating
 | `AUDIO`      | An audio recording                |
 | `BOOK`       | A bound book                      |
 | `CARD`       | A card or file entry              |
-| `ELECTRONIC` | A digital artifact                |
+| `ELECTRONIC` | A digital artifact such as a computer file or a scan |
 | `FICHE`      | Microfiche                        |
 | `FILM`       | Microfilm                         |
 | `MAGAZINE`   | Printed periodical                |


### PR DESCRIPTION
Add descriptive phrase that specifically uses the word scan.
Fixes #623