### PR TITLE
mention encrypted GEDZIP

### DIFF
--- a/specification/gedcom-4-gedzip.md
+++ b/specification/gedcom-4-gedzip.md
@@ -22,6 +22,9 @@ Many other zip-based file formats (such as jar, epub, docx, GEDCOM-X) assign spe
 
 When saved as a file, a GEDZIP should use the filename extension `.gdz`.
 
+Zip archives contain the ability to encrypt their contents, with multiple encryption algorithms supported by the zip archive specification.
+Encrypted GEDZIP files are a recommended way to encrypt FamilySearch GEDCOM data in cases when such encryption is desired.
+
 :::note
 A few details about the zip archive format are useful to fully understand GEDZIP:
 


### PR DESCRIPTION
Resolve #637

I think this is a patch, not a minor version, because encryption was always included in the referenced .zip file format specification, and hence always allowed by GEDZIP through that, even though that permission was not called out explicitly in the GEDZIP specification.