### PR TITLE
Add example of PHRASE with non-OTHER enum

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1137,7 +1137,7 @@ A name given to a foundling orphan might be
 :::
 
 :::example
-A record specificying a performer's "stage name" (a type of professional name) might become
+A record specifying a performer's "stage name" (a type of professional name) might become
 
 ````gedcom
 1 NAME Groucho /Marx/

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1137,12 +1137,12 @@ A name given to a foundling orphan might be
 :::
 
 :::example
-A record specifying a performer's "stage name" (a type of professional name) might become
+A record specifying a writer's "pen name" (a type of professional name) might become
 
 ````gedcom
-1 NAME Groucho /Marx/
+1 NAME Mark /Twain/
 2 TYPE PROFESSIONAL
-3 PHRASE Stage
+3 PHRASE Pen
 ````
 :::
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -1136,6 +1136,16 @@ A name given to a foundling orphan might be
 ````
 :::
 
+:::example
+A record specificying a performer's "stage name" (a type of professional name) might become
+
+````gedcom
+1 NAME Groucho /Marx/
+2 TYPE PROFESSIONAL
+3 PHRASE Stage
+````
+:::
+
 
 #### `PLAC` (Place) `g7:PLAC`
 


### PR DESCRIPTION
As noted in #638, we have multiple PHRASE examples but none paired the PHRASE with a non-OTHER enumeration; this PR adds such an example.