### PR TITLE
Clarify FilePath syntax regarding non-ASCII characters

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -339,8 +339,8 @@ Special = Text
 ## File Path
 
 The file path data type describes where an digital file is located in a machine-readable way.
-Syntactically, the payload is a URI reference as defined by [RFC 3986](https://www.rfc-editor.org/info/rfc3986), or a valid URL string as defined by the [WHATWG URL specification](https://url.spec.whatwg.org/).
-That is, it can be an absolute or relative URL, optionally with a fragment string.
+Syntactically, the payload is a "valid URL string" as defined by the [WHATWG URL specification](https://url.spec.whatwg.org/).
+That is, it can be an absolute or relative URL, optionally with a fragment string, and can contain non-ASCII characters that are permitted in a valid URL string.
 
 Version 7.0 only supports the following URLs:
 
@@ -350,14 +350,14 @@ Version 7.0 only supports the following URLs:
     and should be avoided in datasets that are expected to be shared on the web or with unknown parties,
     but may be appropriate for close collaboration between parties with known similar file structures.
 
-- A URI reference with all of the following:
+- A URI reference, as defined by [RFC 3986](https://www.rfc-editor.org/info/rfc3986), with all of the following:
     - no scheme
     - not beginning with `/` (U+002F)
     - not containing any path segments equal to `..` (U+002E U+002E)
     - not containing a reverse solidus character (U+005C `\`) or `banned` character, either directly or in escaped form
     - no query or fragment
     
-    refers to a **local file**. If the dataset is part of a [GEDZIP file](#gedzip), the URL of the local file is a zip archive filename; otherwise, the URL of a local file is resolved with *base* equal to the directory containing the dataset.
+    refers to a **local file**. If the dataset is part of a [GEDZIP file](#gedzip), the URL of the local file is a zip archive filename; otherwise, the URL of a local file is resolved with *base* equal to the directory containing the dataset.  Note that a URI reference cannot contain non-ASCII characters directly but instead percent-encodes them.
     
     It is recommended that local files use the directory prefix `media/`, but doing so is not required.
 


### PR DESCRIPTION
Fixes #648

Defines the payload as just being a "valid URL string" (not "or URI reference") since the former includes the latter.

Explicitly stated that URLs can contain non-ascii characters as permitted in a "valid URL string".

Moved RFC 3986 link down to the bullet that already constrained local (but not remote) file paths to be URI references.

Explicitly stated that a local path requires percent-encoding non-ASCII characters, since the spec already required that to be the case.