### PR TITLE
Editorial nits

### DIFF
--- a/specification/gedcom-2-data-types.md
+++ b/specification/gedcom-2-data-types.md
@@ -380,7 +380,7 @@ rather, they are used as machine-readable identifiers with formally-defined mean
 
 The payload is a "URI Reference" as defined in [RFC 3986 section 4.1](https://www.rfc-editor.org/rfc/rfc3986#section-4.1) with ABNF production `URI-reference`.
 The URI Reference is a more restrictive syntax than the URL Strings permitted by the [File Path] data type,
-faciltiating easier automated equality tests between URIs.
+facilitating easier automated equality tests between URIs.
 
 Relative URIs should be avoided in datasets that are expected to be shared on the web or with unknown parties,
 but may be appropriate for close collaboration between parties with a shared base URI.

--- a/specification/gedcom-3-structures-1-organization.md
+++ b/specification/gedcom-3-structures-1-organization.md
@@ -808,12 +808,12 @@ n FACT <Text>                              {1:1}  g7:INDI-FACT
 ]
 ````
 
-Individual attributes; see [Individual Attributes](#individual-attributes) for descriptions of each individual attribute type..
+Individual attributes; see [Individual Attributes](#individual-attributes) for descriptions of each individual attribute type.
 
 :::note
 Individual attribute structures vary as follows:
 
-- `INDI`.`NCHI` and `NMR` have [Integer](#text) payloads; `IDNO` and `SSN` have [Special](#special) payloads; others have [Text](#text) payloads
+- `INDI`.`NCHI` and `NMR` have [Integer](#integer) payloads; `IDNO` and `SSN` have [Special](#special) payloads; others have [Text](#text) payloads
 - `INDI`.`FACT` and `IDNO` require `TYPE`; it's optional for others
 :::
 

--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -273,9 +273,9 @@ See `ASSOCIATION_STRUCTURE` for more details.
 
 The person, agency, or entity who created the record. For a published work, this could be the author, compiler, transcriber, abstractor, or editor. For an unpublished source, this may be an individual, a government agency, church organization, or private organization.
 
-#### `BAPL` (Baptism, Latter-Day Saint) `g7:BAPL`
+#### `BAPL` (Baptism, Latter-day Saint) `g7:BAPL`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
 #### `BAPM` (Baptism) `g7:BAPM`
@@ -328,7 +328,7 @@ It is often used subordinate to a death event to show cause of death, such as mi
 
 #### `CENS` (Census)  `g7:FAM-CENS`
 
-An [Family Event](#family-events).
+A [Family Event](#family-events).
 
 #### `CENS` (Census)  `g7:INDI-CENS`
 
@@ -365,9 +365,9 @@ See `ADDRESS_STRUCTURE` for more details.
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `CONL` (Confirmation, Latter-Day Saint) `g7:CONL`
+#### `CONL` (Confirmation, Latter-day Saint) `g7:CONL`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
 #### `CONT` (Continued) `g7:CONT`
@@ -523,9 +523,9 @@ The version 5.5.1 specification contained a typo where this tag was sometimes wr
 An [Individual Event](#individual-events).
 See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
-#### `ENDL` (Endowment, Latter-Day Saint) `g7:ENDL`
+#### `ENDL` (Endowment, Latter-day Saint) `g7:ENDL`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
 #### `ENGA` (Engagement) `g7:ENGA`
@@ -755,9 +755,9 @@ See also `INDIVIDUAL_EVENT_STRUCTURE`.
 
 See `INDIVIDUAL_RECORD`.
 
-#### `INIL` (Initiatory, Latter-Day Saint) `g7:INIL`
+#### `INIL` (Initiatory, Latter-day Saint) `g7:INIL`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.  Previously, GEDCOM versions 3.0 through 5.3 called this `WAC`; it was not part of 5.4 through 5.5.1.
 FamilySearch GEDCOM 7.0 reintroduced it with the name `INIL` for consistency with `BAPL`, `CONL`, and `ENDL`.
 
@@ -1317,12 +1317,12 @@ An enumerated value from set `g7:enumset-SEX` that indicates the sex of the indi
 
 #### `SLGC` (Sealing, child) `g7:SLGC`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_INDIVIDUAL_ORDINANCE`.
 
 #### `SLGS` (Sealing, spouse) `g7:SLGS`
 
-A [Latter-Day Saint Ordinance](#latter-day-saint-ordinances).
+A [Latter-day Saint Ordinance](#latter-day-saint-ordinances).
 See also `LDS_SPOUSE_SEALING`.
 
 #### `SNOTE` (Shared note) `g7:SNOTE`
@@ -1368,11 +1368,11 @@ See `ADDRESS_STRUCTURE` for more details.
 
 #### `STAT` (Status) `g7:ord-STAT`
 
-An enumerated value from set `g7:enumset-ord-STAT` assessing of the state or condition of an ordinance.
+An enumerated value from set `g7:enumset-ord-STAT` assessing the state or condition of an ordinance.
 
 #### `STAT` (Status) `g7:FAMC-STAT`
 
-An enumerated value from set `g7:enumset-FAMC-STAT` assessing of the state or condition of a researcher's belief in a family connection.
+An enumerated value from set `g7:enumset-FAMC-STAT` assessing the state or condition of a researcher's belief in a family connection.
 
 #### `SUBM` (Submitter) `g7:SUBM`
 

--- a/specification/gedcom-3-structures-4-enumerations.md
+++ b/specification/gedcom-3-structures-4-enumerations.md
@@ -118,7 +118,7 @@ The structures for representing the strength of and confidence in various claims
 | `LOCKED` | Some systems may ignore changes to this data. |
 | `PRIVACY` | This data is not to be shared outside of a trusted circle, generally because it contains information about living individuals. This definition is known to admit multiple interpretations, so use of the `PRIVACY` restriction notice is not recommended. |
 
-It is recommended that applications allow users to chose how `CONFIDENTIAL` and/or `PRIVACY` data is handled
+It is recommended that applications allow users to choose how `CONFIDENTIAL` and/or `PRIVACY` data is handled
 when interfacing with other users or applications,
 for example by allowing them to exclude such data when exporting.
 
@@ -198,7 +198,7 @@ The structures for representing the strength of and confidence in various claims
 ### `g7:enumset-ord-STAT`
 
 These values were formerly used by The Church of Jesus Christ of Latter-day Saints for coordinating between temples and members.
-They are no longer used in that way, meaning their interpretation is subject to individual user interpretation
+They are no longer used in that way, meaning their interpretation is subject to individual user interpretation.
 
 The definition of some of these values combined with the official policies of the church
 mean that some values only make sense under a subset of [ordinance structures](#latter-day-saint-ordinances).
@@ -224,7 +224,7 @@ and applications should be prepared to encounter non-current values.
 | `EXCLUDED` | All | Patron excluded this ordinance from being cleared in this submission. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |
 | `DNS` | `SLGC`, `SLGS` | This ordinance is not authorized. | Current |
 | `DNS_CAN` | `SLGS` | This ordinance is not authorized, and the previous ordinance is cancelled. | Current |
-| `INFANT` | All but `SLGC` | Died before less than 1 year old, baptism or endowment not required. | Deprecated. Use `CHILD` instead. |
+| `INFANT` | All but `SLGC` | Died before 1 year old, baptism or endowment not required. | Deprecated. Use `CHILD` instead. |
 | `PRE_1970` | All | Ordinance was likely completed because an ordinance for this person was converted from temple records of work completed before 1970. | Deprecated.  Use `DATE BEF 1970` instead. |
 | `STILLBORN` | All | Born dead, so no ordinances are required. | Current |
 | `SUBMITTED` | All | Ordinance was previously submitted. | Deprecated. This status was defined for use with TempleReady which is no longer in use. |


### PR DESCRIPTION
I asked copilot to review some of the files looking for editorial issues. This PR fixes the ones found in the files touched.

For example, "Latter-Day Saints" should be "Latter-day Saints", not just in the name of the Church.

https://newsroom.churchofjesuschrist.org/article/latter-day-saints-101 is an example of a Church article that uses the term by itself in several places.