### PR TITLE
Add handling `nonconformant tags` in TSV creation

### DIFF
--- a/build/yaml-to-tsv.py
+++ b/build/yaml-to-tsv.py
@@ -89,6 +89,8 @@ for uri,obj in data.items():
         rows.add((sup, obj['standard tag'], uri))
       for tag in obj.get('extension tags',[]):
         rows.add((sup, tag, uri))
+      for tag in obj.get('nonconformant tags',[]):
+        rows.add((sup, tag, uri))
     if len(obj['superstructures']) == 0:
       if 'standard tag' in obj:
         rows.add(('', obj['standard tag'], uri))


### PR DESCRIPTION
This addition has no impact for standard structures, but it is needed for some extensions as noted in https://github.com/FamilySearch/GEDCOM-registries/issues/258