### PR TITLE
Add headers to TSV files

### DIFF
--- a/build/yaml-to-tsv.py
+++ b/build/yaml-to-tsv.py
@@ -43,6 +43,7 @@ for uri,obj in data.items():
         raise Exception(f"{uri} and {sub} disagree about their mutual cardinality")
       rows[(uri, sub)] = card
 with open(Path(args.dest, "cardinalities.tsv"), 'w') as dst:
+  print('superstructure\tstructure\tcardinality', file=dst)
   for row in sorted([k+(v,) for k,v in rows.items()]):
     print('\t'.join(row), file=dst)
 
@@ -56,6 +57,7 @@ for uri,obj in data.items():
     for u in obj['value of']:
       rows.add((u,uri))
 with open(Path(args.dest, "enumerationsets.tsv"), 'w') as dst:
+  print('set\tvalue', file=dst)
   for row in sorted(rows):
     print('\t'.join(row), file=dst)
 
@@ -66,6 +68,7 @@ for uri,obj in data.items():
   if obj['type'] == 'structure' and 'enumeration set' in obj:
     rows.add((uri, obj['enumeration set']))
 with open(Path(args.dest, "enumerations.tsv"), 'w') as dst:
+  print('structure\tset', file=dst)
   for row in sorted(rows):
     print('\t'.join(row), file=dst)
 
@@ -76,6 +79,7 @@ for uri,obj in data.items():
   if obj['type'] == 'structure':
     rows.add((uri, obj['payload'] or ''))
 with open(Path(args.dest, "payloads.tsv"), 'w') as dst:
+  print('structure\tpayload', file=dst)
   for row in sorted(rows):
     print('\t'.join(row), file=dst)
 
@@ -102,5 +106,6 @@ for uri,obj in data.items():
       for tag in data[sub].get('extension tags',[]):
         rows.add((uri, tag, sub))
 with open(Path(args.dest, "substructures.tsv"), 'w') as dst:
+  print('superstructure\ttag\tstructure', file=dst)
   for row in sorted(rows):
     print('\t'.join(row), file=dst)

--- a/extracted-files/cardinalities.tsv
+++ b/extracted-files/cardinalities.tsv
@@ -1,3 +1,4 @@
+superstructure	structure	cardinality
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/ADR1	{0:1}
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/ADR2	{0:1}
 https://gedcom.io/terms/v7/ADDR	https://gedcom.io/terms/v7/ADR3	{0:1}

--- a/extracted-files/enumerations.tsv
+++ b/extracted-files/enumerations.tsv
@@ -1,3 +1,4 @@
+structure	set
 https://gedcom.io/terms/v7/DATA-EVEN	https://gedcom.io/terms/v7/enumset-EVENATTR
 https://gedcom.io/terms/v7/FAMC-ADOP	https://gedcom.io/terms/v7/enumset-ADOP
 https://gedcom.io/terms/v7/FAMC-STAT	https://gedcom.io/terms/v7/enumset-FAMC-STAT

--- a/extracted-files/enumerationsets.tsv
+++ b/extracted-files/enumerationsets.tsv
@@ -1,3 +1,4 @@
+set	value
 https://gedcom.io/terms/v7/enumset-ADOP	https://gedcom.io/terms/v7/enum-ADOP-HUSB
 https://gedcom.io/terms/v7/enumset-ADOP	https://gedcom.io/terms/v7/enum-ADOP-WIFE
 https://gedcom.io/terms/v7/enumset-ADOP	https://gedcom.io/terms/v7/enum-BOTH

--- a/extracted-files/payloads.tsv
+++ b/extracted-files/payloads.tsv
@@ -1,3 +1,4 @@
+structure	payload
 https://gedcom.io/terms/v7/ABBR	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/ADDR	http://www.w3.org/2001/XMLSchema#string
 https://gedcom.io/terms/v7/ADOP	Y|<NULL>

--- a/extracted-files/substructures.tsv
+++ b/extracted-files/substructures.tsv
@@ -1,3 +1,4 @@
+superstructure	tag	structure
 	CONT	https://gedcom.io/terms/v7/CONT
 	FAM	https://gedcom.io/terms/v7/record-FAM
 	HEAD	https://gedcom.io/terms/v7/HEAD


### PR DESCRIPTION
Up to this point, the TSV files in this repository's `extracted_files/` directory lacked header rows, but the same TSV files in the https://github.com/FamilySearch/GEDCOM-registries repository's `generated_files` directory had them. This PR makes the two the same, both with header rows.

There is a small chance this may trip up some existing software that uses the files, where they think there is (e.g.) a structure with URI `structure`, but that should be a single-line fix for any such application and makes the files easier to read and understand.