### PR TITLE
Add tooling to support cross-major-version subsumes

### DIFF
--- a/build/extract-yaml.py
+++ b/build/extract-yaml.py
@@ -563,13 +563,18 @@ if __name__ == '__main__':
         assert sub.split('/')[4] <= v, f"Enumeration value {sub} incompatible with enumset {uri}"
     
 
-  # step 12: add subsumes for any URI that also exists in earlier minor version
+  # step 12: add subsumes for any URI that also exists in earlier minor version or in subsumes.tsv
   from subprocess import run
   for uri in data:
     if '/v7.1/' in uri:
       res = run(['git','show','main:'+pathof[uri]], capture_output=True)
       if not res.returncode:
         data[uri].subsumes.append(uri.replace('/v7.1/', '/v7/'))
+  with open(Path(args.spec, 'subsumes.tsv'),'r') as subs_csv:
+    subs_csv_header = next(subs_csv)
+    for line in subs_csv:
+      old,new = line.strip('\n\r').split('\t')
+      if new in data: data[new].subsumes.append(old)
 
   # step 13: write all the YAML files
   for uri in data:

--- a/extracted-files/tags/ABBR
+++ b/extracted-files/tags/ABBR
@@ -22,5 +22,8 @@ substructures: {}
 superstructures:
   "https://gedcom.io/terms/v7/record-SOUR": "{0:1}"
 
+subsumes:
+  - "https://gedcom.io/terms/v5.5.1/ABBR"
+
 contact: "https://gedcom.io/community/"
 ...

--- a/specification/subsumes.tsv
+++ b/specification/subsumes.tsv
@@ -1,0 +1,2 @@
+may-convert-from	may-convert-to
+https://gedcom.io/terms/v5.5.1/ABBR	https://gedcom.io/terms/v7/ABBR


### PR DESCRIPTION
The initial `specification/subsumes.tsv` created by this PR contains just a single entry, `ABBR`, which has the same defintion (modulo things like CONC and line value length limits) in both 5.5.1 an 7.0. It is present as a placeholder to demonstrate that this tooling works, but will cause a change to the ABBR 7.0 YAML file so the choice of that specific placeholder should be reviewed to ensure we agree that it is truly a subsumption.

Resolve #757