### PR TITLE
copy head-note-data deprecation to section 3.3.4

### DIFF
--- a/specification/gedcom-3-structures-3-meaning.md
+++ b/specification/gedcom-3-structures-3-meaning.md
@@ -441,6 +441,10 @@ The database, electronic data source, or digital repository from which this data
 The payload is the name of the database, electronic data source, or digital repository,
 with substructures providing additional details about it (not about the export).
 
+:::deprecation
+`HEAD`.`SOUR`.`DATA` should not be added to new files; see `HEADER` for more details.
+:::
+
 #### `DATE` (Date) `g7:DATE`
 
 The principal date of the subject of the superstructure.


### PR DESCRIPTION
`g7:HEAD-SOUR-DATA` is deprecated, as is noted in section 3.2.1 under `HEADER` but not in 3.3.4 under `HEAD-SOUR-DATA`.

This PR adds the deprecation note to section 3.3.4. A similar PR was previously done in v7.1 but not v7.0